### PR TITLE
websocket not connecting on Windows

### DIFF
--- a/packages/docz-core/src/commands/args.ts
+++ b/packages/docz-core/src/commands/args.ts
@@ -91,7 +91,7 @@ export const args = (yargs: any) => {
   })
   yargs.positional('host', {
     type: 'string',
-    default: process.env.HOST || '0.0.0.0',
+    default: process.env.HOST || '127.0.0.1',
   })
   yargs.positional('port', {
     alias: 'p',
@@ -100,7 +100,7 @@ export const args = (yargs: any) => {
   })
   yargs.positional('websocketHost', {
     type: 'string',
-    default: process.env.WEBSOCKET_HOST || '0.0.0.0',
+    default: process.env.WEBSOCKET_HOST || '127.0.0.1',
   })
   yargs.positional('websocketPort', {
     type: 'number',


### PR DESCRIPTION
Fixes #15 

The websocket won't connect on windows when the host is set to '0.0.0.0'. The app compiles but does not create any documents. 
Currently you have to override the `host` and `websocketHost` values in the `doczrc.js` to make the documents appear. 
This PR changes the default to `127.0.0.1` which works on both mac and windows. 
