### PR TITLE
Fix documentation for babel plugin

### DIFF
--- a/packages/docz-plugin-babel6/README.md
+++ b/packages/docz-plugin-babel6/README.md
@@ -3,7 +3,7 @@
 By default and by some performance issues, Docz use Babel@7. If you want to use older versions of babel import this plugin and use on your `doczrc.js`:
 
 ```js
-import { babel } from 'docz-plugin-babel6'
+import { babel6 } from 'docz-plugin-babel6'
 
 export default {
   plugins: [babel6()]

--- a/packages/docz-plugin-babel6/README.md
+++ b/packages/docz-plugin-babel6/README.md
@@ -3,9 +3,9 @@
 By default and by some performance issues, Docz use Babel@7. If you want to use older versions of babel import this plugin and use on your `doczrc.js`:
 
 ```js
-import { babel6 } from 'docz-plugin-babel6'
+import { babel } from 'docz-plugin-babel6'
 
 export default {
-  plugins: [babel6()]
+  plugins: [babel()]
 }
 ```

--- a/packages/docz-plugin-babel6/src/index.ts
+++ b/packages/docz-plugin-babel6/src/index.ts
@@ -9,7 +9,7 @@ const modifyHappypackLoader = (plugin: any) => {
   plugin.config.loaders[0].loader = require.resolve('babel-loader')
 }
 
-export const babel6 = () =>
+export const babel = () =>
   createPlugin({
     modifyBabelRc: (babelrc: BabelRC) => {
       if (!babelrc.presets) return babelrc

--- a/packages/docz-plugin-babel6/src/index.ts
+++ b/packages/docz-plugin-babel6/src/index.ts
@@ -9,7 +9,7 @@ const modifyHappypackLoader = (plugin: any) => {
   plugin.config.loaders[0].loader = require.resolve('babel-loader')
 }
 
-export const babel = () =>
+export const babel6 = () =>
   createPlugin({
     modifyBabelRc: (babelrc: BabelRC) => {
       if (!babelrc.presets) return babelrc


### PR DESCRIPTION
### Description

Add here a description about your Pull Request

The README for docz-plugin-babel6 currently wont work. 

It currently says
```javascript
import { babel } from 'docz-plugin-babel6'
export default { plugins[babel6()] };
```
But this will result in 'babel6 is not defined' 

In this PR I have changed the export name from the plugin to be babel6 as this makes most sense to me. 
It would possibly be safer, but may make less sense, to just update the README to either

- change the import to `import { babel as babel6 }`
- keep the current import and do `plugins[babel()]`, which is less descriptive. 

### Review

- [ ] Test out the new plugin