### PR TITLE
Throws errors and exist when config encounters an error

### DIFF
--- a/packages/load-cfg/package.json
+++ b/packages/load-cfg/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@types/find-up": "^2.1.1",
-    "@types/node": "^10.3.2"
+    "@types/node": "^10.3.2",
+    "libundler": "^1.7.1"
   }
 }

--- a/packages/load-cfg/package.json
+++ b/packages/load-cfg/package.json
@@ -27,7 +27,6 @@
   },
   "devDependencies": {
     "@types/find-up": "^2.1.1",
-    "@types/node": "^10.3.2",
-    "libundler": "^1.7.1"
+    "@types/node": "^10.3.2"
   }
 }

--- a/packages/load-cfg/src/index.ts
+++ b/packages/load-cfg/src/index.ts
@@ -43,7 +43,8 @@ export const loadFile = (
       file = JSON.parse(fs.readFileSync(filepath, 'utf-8'))
     }
   } catch (err) {
-    file = defaultFile
+    console.warn('There was an error loading your doczrc.js config:')
+    throw err
   }
 
   return file

--- a/packages/load-cfg/src/index.ts
+++ b/packages/load-cfg/src/index.ts
@@ -43,7 +43,7 @@ export const loadFile = (
       file = JSON.parse(fs.readFileSync(filepath, 'utf-8'))
     }
   } catch (err) {
-    console.warn('There was an error loading your doczrc.js config:')
+    console.warn('There was an error loading your config:')
     throw err
   }
 


### PR DESCRIPTION
Addresses #69 

### Description

Previously, the config loader would fall back to the default configuration when it encountered an error loading `doczrc.js`. This PR changes the behavior to report the error and fail instead.