### PR TITLE
feat(docz-theme-default): add responsiveness

### DIFF
--- a/packages/docz-theme-default/package.json
+++ b/packages/docz-theme-default/package.json
@@ -23,6 +23,7 @@
     "docz": "^0.2.7",
     "emotion": "^9.2.1",
     "emotion-theming": "^9.2.1",
+    "facepaint": "^1.2.1",
     "fast-deep-equal": "^2.0.1",
     "prismjs": "^1.14.0",
     "prop-types": "15.6.1",

--- a/packages/docz-theme-default/package.json
+++ b/packages/docz-theme-default/package.json
@@ -28,6 +28,7 @@
     "prismjs": "^1.14.0",
     "prop-types": "15.6.1",
     "react": "^16.4.0",
+    "react-breakpoints": "^3.0.0",
     "react-dom": "^16.4.0",
     "react-emotion": "^9.2.1",
     "react-feather": "^1.1.0",

--- a/packages/docz-theme-default/src/components/shared/Sidebar/Menu.tsx
+++ b/packages/docz-theme-default/src/components/shared/Sidebar/Menu.tsx
@@ -32,9 +32,10 @@ const Icon = styled.div`
 export interface MenuProps {
   menu: string
   docs: Entry[]
+  sidebarToggle: (ev: React.SyntheticEvent<any>) => void
 }
 
-export const Menu: SFC<MenuProps> = ({ menu, docs }) => (
+export const Menu: SFC<MenuProps> = ({ menu, docs, sidebarToggle }) => (
   <Toggle initial={false}>
     {({ on, toggle }: any) => {
       const handleToggle = (ev: React.SyntheticEvent<any>) => {
@@ -54,7 +55,7 @@ export const Menu: SFC<MenuProps> = ({ menu, docs }) => (
             <dl>
               {docs.map(doc => (
                 <dt key={doc.id}>
-                  <Link to={doc.route}>{doc.name}</Link>
+                  <Link onClick={sidebarToggle} to={doc.route}>{doc.name}</Link>
                 </dt>
               ))}
             </dl>

--- a/packages/docz-theme-default/src/components/shared/Sidebar/Menu.tsx
+++ b/packages/docz-theme-default/src/components/shared/Sidebar/Menu.tsx
@@ -55,7 +55,9 @@ export const Menu: SFC<MenuProps> = ({ menu, docs, sidebarToggle }) => (
             <dl>
               {docs.map(doc => (
                 <dt key={doc.id}>
-                  <Link onClick={sidebarToggle} to={doc.route}>{doc.name}</Link>
+                  <Link onClick={sidebarToggle} to={doc.route}>
+                    {doc.name}
+                  </Link>
                 </dt>
               ))}
             </dl>

--- a/packages/docz-theme-default/src/components/shared/Sidebar/index.tsx
+++ b/packages/docz-theme-default/src/components/shared/Sidebar/index.tsx
@@ -185,8 +185,7 @@ const Icon = styled('div')`
 export const Sidebar = () => (
   <Toggle initial={false}>
     {({ on, toggle }: any) => {
-      const handleToggle = (ev: React.SyntheticEvent<any>) => {
-        ev.preventDefault()
+      const handleSidebarToggle = (ev: React.SyntheticEvent<any>) => {
         toggle()
       }
       return (
@@ -199,7 +198,7 @@ export const Sidebar = () => (
             return (
               <React.Fragment>
                 <Wrapper opened={on}>
-                  <ToggleBlock opened={on} onClick={handleToggle}>
+                  <ToggleBlock opened={on} onClick={handleSidebarToggle}>
                     <Icon opened={on}>
                       <span className="icon__line" />
                       <span className="icon__line" />
@@ -221,12 +220,12 @@ export const Sidebar = () => (
                   </ThemeConfig>
                   <Menus>
                     {docsWithoutMenu.map(doc => (
-                      <Link key={doc.id} to={doc.route}>
+                      <Link key={doc.id} to={doc.route} onClick={handleSidebarToggle}>
                         {doc.name}
                       </Link>
                     ))}
                     {menus.map(menu => (
-                      <Menu key={menu} menu={menu} docs={fromMenu(menu)} />
+                      <Menu key={menu} sidebarToggle={handleSidebarToggle} menu={menu} docs={fromMenu(menu)} />
                     ))}
                   </Menus>
                   <Footer>
@@ -236,7 +235,7 @@ export const Sidebar = () => (
                     </a>
                   </Footer>
                 </Wrapper>
-                <ToggleBackground opened={on} onClick={handleToggle} />
+                <ToggleBackground opened={on} onClick={handleSidebarToggle} />
               </React.Fragment>
             )
           }}

--- a/packages/docz-theme-default/src/components/shared/Sidebar/index.tsx
+++ b/packages/docz-theme-default/src/components/shared/Sidebar/index.tsx
@@ -15,7 +15,7 @@ const wrapperToggle = (p: Wrapper) => (p.opened ? '-90%' : '0')
 
 const Wrapper = styled('div')`
   ${p => p.theme.mq({
-    position: ['absolute', 'absolute', 'relative']
+    position: ['absolute', 'absolute', 'absolute', 'relative']
   })};
   display: flex;
   flex-direction: column;
@@ -99,12 +99,32 @@ const Footer = styled('div')`
 `
 
 const ToggleBlock = styled('div')`
+  ${p => p.theme.mq({
+    display: ['block', 'block', 'block', 'none']
+  })};
   position: absolute;
   width: 32px;
   height: 32px;
   top: 0;
   right: 0;
   cursor: pointer;
+`
+
+interface ToggleBackgroundProps {
+  opened: boolean
+}
+
+const ToggleBackgroundAppear = (p: ToggleBackgroundProps) => (p.opened ? 'none' : 'block')
+
+const ToggleBackground = styled('div')`
+  display: ${ToggleBackgroundAppear};
+  content: '';
+  background-color: rgba(0, 0, 0, .2);
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  top: 0; bottom: 0; left: 0; right: 0;
+  z-index: 99;
 `
 
 interface IconProps {
@@ -142,38 +162,41 @@ export const Sidebar = () => (
               docs.filter(doc => doc.menu === menu)
 
             return (
-              <Wrapper opened={on}>
-                <ToggleBlock onClick={handleToggle}>
-                  <Icon opened={on}>
-                    <ChevronDown size={15} />
-                  </Icon>
-                </ToggleBlock>
-                <ThemeConfig>
-                  {({ title, logo }) =>
-                    logo ? (
-                      <LogoImg src={logo.src} width={logo.width} alt={title} />
-                    ) : (
-                      <LogoText>{title}</LogoText>
-                    )
-                  }
-                </ThemeConfig>
-                <Menus>
-                  {docsWithoutMenu.map(doc => (
-                    <Link key={doc.id} to={doc.route}>
-                      {doc.name}
-                    </Link>
-                  ))}
-                  {menus.map(menu => (
-                    <Menu key={menu} menu={menu} docs={fromMenu(menu)} />
-                  ))}
-                </Menus>
-                <Footer>
-                  Built with
-                  <a href="#" target="_blank">
-                    <img src={logo} width={40} alt="Docz" />
-                  </a>
-                </Footer>
-              </Wrapper>
+              <React.Fragment>
+                <Wrapper opened={on}>
+                  <ToggleBlock onClick={handleToggle}>
+                    <Icon opened={on}>
+                      <ChevronDown size={15} />
+                    </Icon>
+                  </ToggleBlock>
+                  <ThemeConfig>
+                    {({ title, logo }) =>
+                      logo ? (
+                        <LogoImg src={logo.src} width={logo.width} alt={title} />
+                      ) : (
+                        <LogoText>{title}</LogoText>
+                      )
+                    }
+                  </ThemeConfig>
+                  <Menus>
+                    {docsWithoutMenu.map(doc => (
+                      <Link key={doc.id} to={doc.route}>
+                        {doc.name}
+                      </Link>
+                    ))}
+                    {menus.map(menu => (
+                      <Menu key={menu} menu={menu} docs={fromMenu(menu)} />
+                    ))}
+                  </Menus>
+                  <Footer>
+                    Built with
+                    <a href="#" target="_blank">
+                      <img src={logo} width={40} alt="Docz" />
+                    </a>
+                  </Footer>
+                </Wrapper>
+                <ToggleBackground opened={on} onClick={handleToggle}/>
+              </React.Fragment>
             )
           }}
         </Docs>

--- a/packages/docz-theme-default/src/components/shared/Sidebar/index.tsx
+++ b/packages/docz-theme-default/src/components/shared/Sidebar/index.tsx
@@ -14,14 +14,17 @@ interface Wrapper {
 const wrapperToggle = (p: Wrapper) => (p.opened ? '-90%' : '0')
 
 const Wrapper = styled('div')`
+  ${p => p.theme.mq({
+    position: ['absolute', 'absolute', 'relative']
+  })};
   display: flex;
-  position: relative;
   flex-direction: column;
   height: 100%;
-  background: ${p => wrapperToggle(p) !== '0' ? p.theme.colors.white : p.theme.colors.grayLight};
+  background: ${p =>
+    wrapperToggle(p) !== '0' ? p.theme.colors.white : p.theme.colors.grayLight};
   transition: transform 0.3s, background 0.3s;
   transform: translateX(${wrapperToggle});
-  z-index: 99;
+  z-index: 100;
 
   ${p => p.theme.styles.sidebar};
 
@@ -135,7 +138,8 @@ export const Sidebar = () => (
         <Docs>
           {({ docs, menus }) => {
             const docsWithoutMenu = docs.filter((doc: Entry) => !doc.menu)
-            const fromMenu = (menu: string) => docs.filter(doc => doc.menu === menu)
+            const fromMenu = (menu: string) =>
+              docs.filter(doc => doc.menu === menu)
 
             return (
               <Wrapper opened={on}>

--- a/packages/docz-theme-default/src/components/shared/Sidebar/index.tsx
+++ b/packages/docz-theme-default/src/components/shared/Sidebar/index.tsx
@@ -2,12 +2,14 @@ import React from 'react'
 import { Docs, Link, Entry, ThemeConfig } from 'docz'
 import styled from 'react-emotion'
 import { Toggle } from 'react-powerplug'
+import { Media } from 'react-breakpoints'
 
 import { Menu } from './Menu'
 import logo from '../../../images/docz.svg'
 
 interface Wrapper {
   opened: boolean
+  desktop: boolean
 }
 
 interface IconProps {
@@ -22,7 +24,7 @@ interface ToggleBackgroundProps {
   opened: boolean
 }
 
-const wrapperToggle = (p: Wrapper) => (p.opened ? '-90%' : '0')
+const wrapperToggle = (p: Wrapper) => (p.opened && !p.desktop ? '-90%' : '0')
 const IconFirst = (p: IconProps) => (p.opened ? '0px' : '12px')
 const IconMiddle = (p: IconProps) => (p.opened ? '1' : '0')
 const IconLast = (p: IconProps) => (p.opened ? '0px' : '-4px')
@@ -183,64 +185,84 @@ const Icon = styled('div')`
 `
 
 export const Sidebar = () => (
-  <Toggle initial={false}>
-    {({ on, toggle }: any) => {
-      const handleSidebarToggle = (ev: React.SyntheticEvent<any>) => {
-        toggle()
-      }
+  <Media>
+    {({ currentBreakpoint }: any) => {
       return (
-        <Docs>
-          {({ docs, menus }) => {
-            const docsWithoutMenu = docs.filter((doc: Entry) => !doc.menu)
-            const fromMenu = (menu: string) =>
-              docs.filter(doc => doc.menu === menu)
-
+        <Toggle initial={true}>
+          {({ on, toggle }: any) => {
+            const isDesktop = currentBreakpoint === 'desktop' ? true : false
+            const handleSidebarToggle = (ev: React.SyntheticEvent<any>) => {
+              if (isDesktop) return
+              toggle()
+            }
             return (
-              <React.Fragment>
-                <Wrapper opened={on}>
-                  <ToggleBlock opened={on} onClick={handleSidebarToggle}>
-                    <Icon opened={on}>
-                      <span className="icon__line" />
-                      <span className="icon__line" />
-                      <span className="icon__line" />
-                    </Icon>
-                  </ToggleBlock>
-                  <ThemeConfig>
-                    {({ title, logo }) =>
-                      logo ? (
-                        <LogoImg
-                          src={logo.src}
-                          width={logo.width}
-                          alt={title}
-                        />
-                      ) : (
-                        <LogoText>{title}</LogoText>
-                      )
-                    }
-                  </ThemeConfig>
-                  <Menus>
-                    {docsWithoutMenu.map(doc => (
-                      <Link key={doc.id} to={doc.route} onClick={handleSidebarToggle}>
-                        {doc.name}
-                      </Link>
-                    ))}
-                    {menus.map(menu => (
-                      <Menu key={menu} sidebarToggle={handleSidebarToggle} menu={menu} docs={fromMenu(menu)} />
-                    ))}
-                  </Menus>
-                  <Footer>
-                    Built with
-                    <a href="#" target="_blank">
-                      <img src={logo} width={40} alt="Docz" />
-                    </a>
-                  </Footer>
-                </Wrapper>
-                <ToggleBackground opened={on} onClick={handleSidebarToggle} />
-              </React.Fragment>
+              <Docs>
+                {({ docs, menus }) => {
+                  const docsWithoutMenu = docs.filter((doc: Entry) => !doc.menu)
+                  const fromMenu = (menu: string) =>
+                    docs.filter(doc => doc.menu === menu)
+
+                  return (
+                    <React.Fragment>
+                      <Wrapper opened={on} desktop={isDesktop}>
+                        <ToggleBlock opened={on} onClick={handleSidebarToggle}>
+                          <Icon opened={on}>
+                            <span className="icon__line" />
+                            <span className="icon__line" />
+                            <span className="icon__line" />
+                          </Icon>
+                        </ToggleBlock>
+                        <ThemeConfig>
+                          {({ title, logo }) =>
+                            logo ? (
+                              <LogoImg
+                                src={logo.src}
+                                width={logo.width}
+                                alt={title}
+                              />
+                            ) : (
+                              <LogoText>{title}</LogoText>
+                            )
+                          }
+                        </ThemeConfig>
+                        <Menus>
+                          {docsWithoutMenu.map(doc => (
+                            <Link
+                              key={doc.id}
+                              to={doc.route}
+                              onClick={handleSidebarToggle}
+                            >
+                              {doc.name}
+                            </Link>
+                          ))}
+                          {menus.map(menu => (
+                            <Menu
+                              key={menu}
+                              sidebarToggle={handleSidebarToggle}
+                              menu={menu}
+                              docs={fromMenu(menu)}
+                            />
+                          ))}
+                        </Menus>
+                        <Footer>
+                          Built with
+                          <a href="#" target="_blank">
+                            <img src={logo} width={40} alt="Docz" />
+                          </a>
+                        </Footer>
+                      </Wrapper>
+                      <ToggleBackground
+                        opened={on}
+                        onClick={handleSidebarToggle}
+                      />
+                    </React.Fragment>
+                  )
+                }}
+              </Docs>
             )
           }}
-        </Docs>
+        </Toggle>
       )
     }}
-  </Toggle>
+  </Media>
 )

--- a/packages/docz-theme-default/src/components/shared/Sidebar/index.tsx
+++ b/packages/docz-theme-default/src/components/shared/Sidebar/index.tsx
@@ -2,16 +2,35 @@ import React from 'react'
 import { Docs, Link, Entry, ThemeConfig } from 'docz'
 import styled from 'react-emotion'
 import { Toggle } from 'react-powerplug'
-import ChevronDown from 'react-feather/dist/icons/chevron-down'
 
 import { Menu } from './Menu'
 import logo from '../../../images/docz.svg'
+
 
 interface Wrapper {
   opened: boolean
 }
 
+interface IconProps {
+  opened: boolean
+}
+
+interface ToggleBlockProps {
+  opened: boolean
+}
+
+interface ToggleBackgroundProps {
+  opened: boolean
+}
+
 const wrapperToggle = (p: Wrapper) => (p.opened ? '-90%' : '0')
+const IconFirst = (p: IconProps) => (p.opened ? '0px' : '12px')
+const IconMiddle = (p: IconProps) => (p.opened ? '1' : '0')
+const IconLast = (p: IconProps) => (p.opened ? '0px' : '-4px')
+const IconRotate = (p: IconProps) => (p.opened ? '0deg' : '45deg')
+const toggleBlockTranslateX = (p: ToggleBlockProps) => (p.opened ? '10px' : '-6px')
+const toggleBlockTranslateY = (p: ToggleBlockProps) => (p.opened ? '4px' : '0px')
+const toggleBackgroundAppear = (p: ToggleBackgroundProps) => (p.opened ? 'none' : 'block')
 
 const Wrapper = styled('div')`
   ${p => p.theme.mq({
@@ -104,46 +123,53 @@ const ToggleBlock = styled('div')`
   })};
   position: absolute;
   width: 32px;
-  height: 32px;
+  height: 36px;
   top: 0;
   right: 0;
   cursor: pointer;
+  transform: translateX(${toggleBlockTranslateX}) translateY(${toggleBlockTranslateY});
+  transition: transform 0.3s;
 `
 
-interface ToggleBackgroundProps {
-  opened: boolean
-}
-
-const ToggleBackgroundAppear = (p: ToggleBackgroundProps) => (p.opened ? 'none' : 'block')
-
 const ToggleBackground = styled('div')`
-  display: ${ToggleBackgroundAppear};
   content: '';
-  background-color: rgba(0, 0, 0, .2);
+  display: ${toggleBackgroundAppear};
   position: fixed;
+  background-color: rgba(0, 0, 0, .2);
   width: 100%;
   height: 100%;
   top: 0; bottom: 0; left: 0; right: 0;
+  cursor: pointer;
   z-index: 99;
 `
 
-interface IconProps {
-  opened: boolean
-}
-
-const iconRotate = (p: IconProps) => (p.opened ? '-90deg' : '90deg')
-
 const Icon = styled('div')`
   position: relative;
-  top: 50%;
-  transform: translateY(-50%) rotate(${iconRotate});
-  transform-origin: 50% 50%;
-  transition: transform 0.3s;
+  width: 28px;
+  height: 32px;
+  margin: auto;
 
-  & svg {
+  & .icon__line {
+    content: '';
     display: block;
-    margin: auto;
-    stroke: ${p => p.theme.colors.main};
+    position: absolute;
+    width: 100%;
+    height: 2px;
+    left: 0; right: 0;
+    background: ${p => p.theme.colors.main};
+    transition: transform 0.3s, opacity 0.3s;
+    & :nth-child(1) {
+      top: 10px;
+      transform: translateY(${IconFirst}) rotate(${IconRotate});
+    }
+    & :nth-child(2) {
+      top: 18px;
+      opacity: ${IconMiddle}
+    }
+    & :nth-child(3) {
+      top: 26px;
+      transform: translateY(${IconLast}) rotate(-${IconRotate});
+    }
   }
 `
 
@@ -164,9 +190,11 @@ export const Sidebar = () => (
             return (
               <React.Fragment>
                 <Wrapper opened={on}>
-                  <ToggleBlock onClick={handleToggle}>
+                  <ToggleBlock opened={on} onClick={handleToggle}>
                     <Icon opened={on}>
-                      <ChevronDown size={15} />
+                      <span className="icon__line"></span>
+                      <span className="icon__line"></span>
+                      <span className="icon__line"></span>
                     </Icon>
                   </ToggleBlock>
                   <ThemeConfig>

--- a/packages/docz-theme-default/src/components/shared/Sidebar/index.tsx
+++ b/packages/docz-theme-default/src/components/shared/Sidebar/index.tsx
@@ -6,7 +6,6 @@ import { Toggle } from 'react-powerplug'
 import { Menu } from './Menu'
 import logo from '../../../images/docz.svg'
 
-
 interface Wrapper {
   opened: boolean
 }
@@ -28,14 +27,18 @@ const IconFirst = (p: IconProps) => (p.opened ? '0px' : '12px')
 const IconMiddle = (p: IconProps) => (p.opened ? '1' : '0')
 const IconLast = (p: IconProps) => (p.opened ? '0px' : '-4px')
 const IconRotate = (p: IconProps) => (p.opened ? '0deg' : '45deg')
-const toggleBlockTranslateX = (p: ToggleBlockProps) => (p.opened ? '10px' : '-6px')
-const toggleBlockTranslateY = (p: ToggleBlockProps) => (p.opened ? '4px' : '0px')
-const toggleBackgroundAppear = (p: ToggleBackgroundProps) => (p.opened ? 'none' : 'block')
+const toggleBlockTranslateX = (p: ToggleBlockProps) =>
+  p.opened ? '10px' : '-6px'
+const toggleBlockTranslateY = (p: ToggleBlockProps) =>
+  p.opened ? '4px' : '0px'
+const toggleBackgroundAppear = (p: ToggleBackgroundProps) =>
+  p.opened ? 'none' : 'block'
 
 const Wrapper = styled('div')`
-  ${p => p.theme.mq({
-    position: ['absolute', 'absolute', 'absolute', 'relative']
-  })};
+  ${p =>
+    p.theme.mq({
+      position: ['absolute', 'absolute', 'absolute', 'relative'],
+    })};
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -118,16 +121,18 @@ const Footer = styled('div')`
 `
 
 const ToggleBlock = styled('div')`
-  ${p => p.theme.mq({
-    display: ['block', 'block', 'block', 'none']
-  })};
+  ${p =>
+    p.theme.mq({
+      display: ['block', 'block', 'block', 'none'],
+    })};
   position: absolute;
   width: 32px;
   height: 36px;
   top: 0;
   right: 0;
   cursor: pointer;
-  transform: translateX(${toggleBlockTranslateX}) translateY(${toggleBlockTranslateY});
+  transform: translateX(${toggleBlockTranslateX})
+    translateY(${toggleBlockTranslateY});
   transition: transform 0.3s;
 `
 
@@ -135,10 +140,13 @@ const ToggleBackground = styled('div')`
   content: '';
   display: ${toggleBackgroundAppear};
   position: fixed;
-  background-color: rgba(0, 0, 0, .2);
+  background-color: rgba(0, 0, 0, 0.2);
   width: 100%;
   height: 100%;
-  top: 0; bottom: 0; left: 0; right: 0;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
   cursor: pointer;
   z-index: 99;
 `
@@ -155,7 +163,8 @@ const Icon = styled('div')`
     position: absolute;
     width: 100%;
     height: 2px;
-    left: 0; right: 0;
+    left: 0;
+    right: 0;
     background: ${p => p.theme.colors.main};
     transition: transform 0.3s, opacity 0.3s;
     & :nth-child(1) {
@@ -164,7 +173,7 @@ const Icon = styled('div')`
     }
     & :nth-child(2) {
       top: 18px;
-      opacity: ${IconMiddle}
+      opacity: ${IconMiddle};
     }
     & :nth-child(3) {
       top: 26px;
@@ -192,15 +201,19 @@ export const Sidebar = () => (
                 <Wrapper opened={on}>
                   <ToggleBlock opened={on} onClick={handleToggle}>
                     <Icon opened={on}>
-                      <span className="icon__line"></span>
-                      <span className="icon__line"></span>
-                      <span className="icon__line"></span>
+                      <span className="icon__line" />
+                      <span className="icon__line" />
+                      <span className="icon__line" />
                     </Icon>
                   </ToggleBlock>
                   <ThemeConfig>
                     {({ title, logo }) =>
                       logo ? (
-                        <LogoImg src={logo.src} width={logo.width} alt={title} />
+                        <LogoImg
+                          src={logo.src}
+                          width={logo.width}
+                          alt={title}
+                        />
                       ) : (
                         <LogoText>{title}</LogoText>
                       )
@@ -223,7 +236,7 @@ export const Sidebar = () => (
                     </a>
                   </Footer>
                 </Wrapper>
-                <ToggleBackground opened={on} onClick={handleToggle}/>
+                <ToggleBackground opened={on} onClick={handleToggle} />
               </React.Fragment>
             )
           }}

--- a/packages/docz-theme-default/src/components/shared/Sidebar/index.tsx
+++ b/packages/docz-theme-default/src/components/shared/Sidebar/index.tsx
@@ -18,7 +18,7 @@ const Wrapper = styled('div')`
   position: relative;
   flex-direction: column;
   height: 100%;
-  background: ${p => p.theme.colors.grayLight};
+  background: ${p => wrapperToggle(p) !== '0' ? p.theme.colors.white : p.theme.colors.grayLight};
   transition: transform 0.3s, background 0.3s;
   transform: translateX(${wrapperToggle});
   z-index: 99;

--- a/packages/docz-theme-default/src/components/shared/Sidebar/index.tsx
+++ b/packages/docz-theme-default/src/components/shared/Sidebar/index.tsx
@@ -1,15 +1,28 @@
 import React from 'react'
 import { Docs, Link, Entry, ThemeConfig } from 'docz'
 import styled from 'react-emotion'
+import { Toggle } from 'react-powerplug'
+import ChevronDown from 'react-feather/dist/icons/chevron-down'
 
 import { Menu } from './Menu'
 import logo from '../../../images/docz.svg'
 
+interface Wrapper {
+  opened: boolean
+}
+
+const wrapperToggle = (p: Wrapper) => (p.opened ? '-90%' : '0')
+
 const Wrapper = styled('div')`
   display: flex;
+  position: relative;
   flex-direction: column;
   height: 100%;
   background: ${p => p.theme.colors.grayLight};
+  transition: transform 0.3s, background 0.3s;
+  transform: translateX(${wrapperToggle});
+  z-index: 99;
+
   ${p => p.theme.styles.sidebar};
 
   a {
@@ -82,41 +95,85 @@ const Footer = styled('div')`
   }
 `
 
-export const Sidebar = () => (
-  <Docs>
-    {({ docs, menus }) => {
-      const docsWithoutMenu = docs.filter((doc: Entry) => !doc.menu)
-      const fromMenu = (menu: string) => docs.filter(doc => doc.menu === menu)
+const ToggleBlock = styled('div')`
+  position: absolute;
+  width: 32px;
+  height: 32px;
+  top: 0;
+  right: 0;
+  cursor: pointer;
+`
 
+interface IconProps {
+  opened: boolean
+}
+
+const iconRotate = (p: IconProps) => (p.opened ? '-90deg' : '90deg')
+
+const Icon = styled('div')`
+  position: relative;
+  top: 50%;
+  transform: translateY(-50%) rotate(${iconRotate});
+  transform-origin: 50% 50%;
+  transition: transform 0.3s;
+
+  & svg {
+    display: block;
+    margin: auto;
+    stroke: ${p => p.theme.colors.main};
+  }
+`
+
+export const Sidebar = () => (
+  <Toggle initial={false}>
+    {({ on, toggle }: any) => {
+      const handleToggle = (ev: React.SyntheticEvent<any>) => {
+        ev.preventDefault()
+        toggle()
+      }
       return (
-        <Wrapper>
-          <ThemeConfig>
-            {({ title, logo }) =>
-              logo ? (
-                <LogoImg src={logo.src} width={logo.width} alt={title} />
-              ) : (
-                <LogoText>{title}</LogoText>
-              )
-            }
-          </ThemeConfig>
-          <Menus>
-            {docsWithoutMenu.map(doc => (
-              <Link key={doc.id} to={doc.route}>
-                {doc.name}
-              </Link>
-            ))}
-            {menus.map(menu => (
-              <Menu key={menu} menu={menu} docs={fromMenu(menu)} />
-            ))}
-          </Menus>
-          <Footer>
-            Built with
-            <a href="#" target="_blank">
-              <img src={logo} width={40} alt="Docz" />
-            </a>
-          </Footer>
-        </Wrapper>
+        <Docs>
+          {({ docs, menus }) => {
+            const docsWithoutMenu = docs.filter((doc: Entry) => !doc.menu)
+            const fromMenu = (menu: string) => docs.filter(doc => doc.menu === menu)
+
+            return (
+              <Wrapper opened={on}>
+                <ToggleBlock onClick={handleToggle}>
+                  <Icon opened={on}>
+                    <ChevronDown size={15} />
+                  </Icon>
+                </ToggleBlock>
+                <ThemeConfig>
+                  {({ title, logo }) =>
+                    logo ? (
+                      <LogoImg src={logo.src} width={logo.width} alt={title} />
+                    ) : (
+                      <LogoText>{title}</LogoText>
+                    )
+                  }
+                </ThemeConfig>
+                <Menus>
+                  {docsWithoutMenu.map(doc => (
+                    <Link key={doc.id} to={doc.route}>
+                      {doc.name}
+                    </Link>
+                  ))}
+                  {menus.map(menu => (
+                    <Menu key={menu} menu={menu} docs={fromMenu(menu)} />
+                  ))}
+                </Menus>
+                <Footer>
+                  Built with
+                  <a href="#" target="_blank">
+                    <img src={logo} width={40} alt="Docz" />
+                  </a>
+                </Footer>
+              </Wrapper>
+            )
+          }}
+        </Docs>
       )
     }}
-  </Docs>
+  </Toggle>
 )

--- a/packages/docz-theme-default/src/components/ui/Table.tsx
+++ b/packages/docz-theme-default/src/components/ui/Table.tsx
@@ -1,11 +1,11 @@
 import styled from 'react-emotion'
 
 export const Table = styled('table')`
-${p =>
-  p.theme.mq({
-    overflowY: ['hidden', 'hidden', 'hidden', 'initial'],
-    display: ['block', 'block', 'block', 'table']
-  })};
+  ${p =>
+    p.theme.mq({
+      overflowY: ['hidden', 'hidden', 'hidden', 'initial'],
+      display: ['block', 'block', 'block', 'table'],
+    })};
   width: 100%;
   padding: 0;
   margin-bottom: 50px;
@@ -31,26 +31,26 @@ ${p =>
     & :nth-child(1) {
       ${p =>
         p.theme.mq({
-          width: ['20%', '20%', '20%', 'auto']
-      })};
+          width: ['20%', '20%', '20%', 'auto'],
+        })};
     }
     & :nth-child(2) {
       ${p =>
         p.theme.mq({
-          width: ['10%', '10%', '10%', 'auto']
-      })};
+          width: ['10%', '10%', '10%', 'auto'],
+        })};
     }
     & :nth-child(3) {
       ${p =>
         p.theme.mq({
-          width: ['10%', '10%', '10%', 'auto']
-      })};
+          width: ['10%', '10%', '10%', 'auto'],
+        })};
     }
     & :nth-child(4) {
       ${p =>
         p.theme.mq({
-          width: ['20%', '20%', '20%', 'auto']
-      })};
+          width: ['20%', '20%', '20%', 'auto'],
+        })};
     }
   }
 

--- a/packages/docz-theme-default/src/components/ui/Table.tsx
+++ b/packages/docz-theme-default/src/components/ui/Table.tsx
@@ -1,6 +1,11 @@
 import styled from 'react-emotion'
 
 export const Table = styled('table')`
+${p =>
+  p.theme.mq({
+    overflowY: ['hidden', 'hidden', 'hidden', 'initial'],
+    display: ['block', 'block', 'block', 'table']
+  })};
   width: 100%;
   padding: 0;
   margin-bottom: 50px;
@@ -23,6 +28,30 @@ export const Table = styled('table')`
     text-align: left;
     font-weight: 400;
     padding: 20px 20px;
+    & :nth-child(1) {
+      ${p =>
+        p.theme.mq({
+          width: ['20%', '20%', '20%', 'auto']
+      })};
+    }
+    & :nth-child(2) {
+      ${p =>
+        p.theme.mq({
+          width: ['10%', '10%', '10%', 'auto']
+      })};
+    }
+    & :nth-child(3) {
+      ${p =>
+        p.theme.mq({
+          width: ['10%', '10%', '10%', 'auto']
+      })};
+    }
+    & :nth-child(4) {
+      ${p =>
+        p.theme.mq({
+          width: ['20%', '20%', '20%', 'auto']
+      })};
+    }
   }
 
   & tbody td {

--- a/packages/docz-theme-default/src/config.ts
+++ b/packages/docz-theme-default/src/config.ts
@@ -1,9 +1,11 @@
 import { styles } from './styles'
 import * as colors from './styles/colors'
 import { prismTheme } from './styles/prism-theme'
+import { mq } from './styles/responsive'
 
 export const config = {
   colors,
   styles,
   prismTheme,
+  mq,
 }

--- a/packages/docz-theme-default/src/config.ts
+++ b/packages/docz-theme-default/src/config.ts
@@ -1,11 +1,12 @@
 import { styles } from './styles'
 import * as colors from './styles/colors'
 import { prismTheme } from './styles/prism-theme'
-import { mq } from './styles/responsive'
+import { mq, breakpoints } from './styles/responsive'
 
 export const config = {
   colors,
   styles,
   prismTheme,
   mq,
+  breakpoints,
 }

--- a/packages/docz-theme-default/src/index.tsx
+++ b/packages/docz-theme-default/src/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { theme, DocPreview, ThemeConfig } from 'docz'
 import { ThemeProvider } from 'emotion-theming'
+import ReactBreakpoints from 'react-breakpoints'
 
 import { config } from './config'
 import { Sidebar, Main } from './components/shared'
@@ -10,27 +11,29 @@ const Theme = () => (
   <ThemeConfig>
     {config => (
       <ThemeProvider theme={config}>
-        <Main config={config}>
-          <Sidebar />
-          <DocPreview
-            components={{
-              page: components.Page,
-              notFound: components.NotFound,
-              render: components.Render,
-              h1: components.H1,
-              h2: components.H2,
-              h3: components.H3,
-              h4: components.H4,
-              h5: components.H5,
-              h6: components.H6,
-              ul: components.List,
-              loading: components.Loading,
-              table: components.Table,
-              pre: components.Pre,
-              tooltip: components.Tooltip,
-            }}
-          />
-        </Main>
+        <ReactBreakpoints breakpoints={config.breakpoints}>
+          <Main config={config}>
+            <Sidebar />
+            <DocPreview
+              components={{
+                page: components.Page,
+                notFound: components.NotFound,
+                render: components.Render,
+                h1: components.H1,
+                h2: components.H2,
+                h3: components.H3,
+                h4: components.H4,
+                h5: components.H5,
+                h6: components.H6,
+                ul: components.List,
+                loading: components.Loading,
+                table: components.Table,
+                pre: components.Pre,
+                tooltip: components.Tooltip,
+              }}
+            />
+          </Main>
+        </ReactBreakpoints>
       </ThemeProvider>
     )}
   </ThemeConfig>

--- a/packages/docz-theme-default/src/styles/index.ts
+++ b/packages/docz-theme-default/src/styles/index.ts
@@ -17,7 +17,7 @@ export const styles = {
   container: {
     padding: '50px 50px 100px',
     width: 960,
-    maxWidth: '100%'
+    maxWidth: '100%',
   },
   h1: {
     margin: '30px 0',

--- a/packages/docz-theme-default/src/styles/index.ts
+++ b/packages/docz-theme-default/src/styles/index.ts
@@ -17,6 +17,7 @@ export const styles = {
   container: {
     padding: '50px 50px 100px',
     width: 960,
+    maxWidth: '100%'
   },
   h1: {
     margin: '30px 0',

--- a/packages/docz-theme-default/src/styles/responsive.ts
+++ b/packages/docz-theme-default/src/styles/responsive.ts
@@ -1,0 +1,7 @@
+import facepaint from 'facepaint'
+
+export const mq = facepaint([
+  '@media(min-width: 420px)',
+  '@media(min-width: 920px)',
+  '@media(min-width: 1120px)'
+])

--- a/packages/docz-theme-default/src/styles/responsive.ts
+++ b/packages/docz-theme-default/src/styles/responsive.ts
@@ -1,7 +1,13 @@
 import facepaint from 'facepaint'
 
+export const breakpoints = {
+  mobile: 420,
+  tablet: 920,
+  desktop: 1120,
+}
+
 export const mq = facepaint([
-  '@media(min-width: 420px)',
-  '@media(min-width: 920px)',
-  '@media(min-width: 1120px)'
+  `@media(min-width: ${breakpoints.mobile}px)`,
+  `@media(min-width: ${breakpoints.tablet}px)`,
+  `@media(min-width: ${breakpoints.desktop}px)`
 ])

--- a/packages/docz-theme-default/src/styles/responsive.ts
+++ b/packages/docz-theme-default/src/styles/responsive.ts
@@ -9,5 +9,5 @@ export const breakpoints = {
 export const mq = facepaint([
   `@media(min-width: ${breakpoints.mobile}px)`,
   `@media(min-width: ${breakpoints.tablet}px)`,
-  `@media(min-width: ${breakpoints.desktop}px)`
+  `@media(min-width: ${breakpoints.desktop}px)`,
 ])

--- a/packages/docz-theme-default/src/types.d.ts
+++ b/packages/docz-theme-default/src/types.d.ts
@@ -9,30 +9,29 @@ declare module '*.svg' {
   export default content
 }
 
-declare module "facepaint" {
-
+declare module 'facepaint' {
   interface Styles {
-    [ruleOrSelector: string]: string | number | Styles;
+    [ruleOrSelector: string]: string | number | Styles
   }
 
   interface MqStyles {
-    [ruleOrSelector: string]: string | string[] | number | number[] | Styles;
+    [ruleOrSelector: string]: string | string[] | number | number[] | Styles
   }
 
-  type Mq = (styles: object) => Styles;
+  type Mq = (styles: object) => Styles
 
   interface FacepaintSettings {
-    literal?: boolean;
-    overlap?: boolean;
+    literal?: boolean
+    overlap?: boolean
   }
 
   type Facepaint = (
     /** media queries to be applied across */
     mediaQueries: [string, string, string],
     settings?: FacepaintSettings
-  ) => Mq;
+  ) => Mq
 
-  const facepaint: Facepaint;
+  const facepaint: Facepaint
 
-  export = facepaint;
+  export = facepaint
 }

--- a/packages/docz-theme-default/src/types.d.ts
+++ b/packages/docz-theme-default/src/types.d.ts
@@ -3,6 +3,7 @@ declare module 'react-powerplug'
 declare module 'react-lightweight-tooltip'
 declare module 'react-feather/dist/icons/chevron-down'
 declare module 'react-spinners'
+declare module 'react-breakpoints'
 
 declare module '*.svg' {
   const content: any

--- a/packages/docz-theme-default/src/types.d.ts
+++ b/packages/docz-theme-default/src/types.d.ts
@@ -8,3 +8,31 @@ declare module '*.svg' {
   const content: any
   export default content
 }
+
+declare module "facepaint" {
+
+  interface Styles {
+    [ruleOrSelector: string]: string | number | Styles;
+  }
+
+  interface MqStyles {
+    [ruleOrSelector: string]: string | string[] | number | number[] | Styles;
+  }
+
+  type Mq = (styles: object) => Styles;
+
+  interface FacepaintSettings {
+    literal?: boolean;
+    overlap?: boolean;
+  }
+
+  type Facepaint = (
+    /** media queries to be applied across */
+    mediaQueries: [string, string, string],
+    settings?: FacepaintSettings
+  ) => Mq;
+
+  const facepaint: Facepaint;
+
+  export = facepaint;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3341,6 +3341,13 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+create-react-context@0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.1.tgz#425a3d96f4b7690c2fbf20aed5aeae2e2007a959"
+  dependencies:
+    fbjs "^0.8.0"
+    gud "^1.0.0"
+
 cross-env@^5.1.6:
   version "5.1.6"
   resolved "https://registry.npmjs.org/cross-env/-/cross-env-5.1.6.tgz#0dc05caf945b24e4b9e3b12871fe0e858d08b38d"
@@ -4246,6 +4253,18 @@ faye-websocket@~0.11.0:
   dependencies:
     websocket-driver ">=0.5.1"
 
+fbjs@^0.8.0:
+  version "0.8.17"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.18"
+
 fbjs@^0.8.1, fbjs@^0.8.16:
   version "0.8.16"
   resolved "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
@@ -4800,6 +4819,10 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.11"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
+gud@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
+
 gzip-size@3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz#546188e9bdc337f673772f81660464b389dce520"
@@ -4971,7 +4994,7 @@ hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
-hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0:
+hoist-non-react-statics@2.5.0, hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0:
   version "2.5.0"
   resolved "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
 
@@ -5960,6 +5983,10 @@ lodash._reinterpolate@~3.0.0:
 lodash.assign@^4.0.3, lodash.assign@^4.0.6:
   version "4.2.0"
   resolved "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
+
+lodash.debounce@4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
 
 lodash.deburr@^4.1.0:
   version "4.1.0"
@@ -7354,6 +7381,14 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-breakpoints@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/react-breakpoints/-/react-breakpoints-3.0.0.tgz#b57d18dc7ad73a7c00c1949e689360af9cac6759"
+  dependencies:
+    create-react-context "0.2.1"
+    hoist-non-react-statics "2.5.0"
+    lodash.debounce "4.0.8"
 
 react-dev-utils@^5.0.1:
   version "5.0.1"
@@ -9018,6 +9053,10 @@ typedarray@^0.0.6:
 typescript@2.9.1, typescript@^2.9.1:
   version "2.9.1"
   resolved "https://registry.npmjs.org/typescript/-/typescript-2.9.1.tgz#fdb19d2c67a15d11995fd15640e373e09ab09961"
+
+ua-parser-js@^0.7.18:
+  version "0.7.18"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.18.tgz#a7bfd92f56edfb117083b69e31d2aa8882d4b1ed"
 
 ua-parser-js@^0.7.9:
   version "0.7.17"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4203,6 +4203,10 @@ extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
 
+facepaint@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/facepaint/-/facepaint-1.2.1.tgz#89929e601b15227278c53c516f764fc462b09c33"
+
 fast-deep-equal@^1.0.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"


### PR DESCRIPTION
### Description

Add responsiveness to docz, including:
- Screen adapts in realtime.
- Sidebar auto hides with button animations.
- Sidebar has toggle button with minimum 32px for better experience in mobile clicks
- Tables are scrollable.
- Performant animations with transform.

Resolves #49

### Review

- [ ] Code implementation
- [ ] Test with some responsive component in playground

### Pre-merge checklist

- [ ] Merge with dark mode code
- [ ] Test on some browsers and phones

### Screenshots

![docz-responsive](https://user-images.githubusercontent.com/5435657/41827174-6f4c8850-7804-11e8-8626-9e0228ab4e5c.gif)
