### PR TITLE
Add overflow: auto to Sidebar

### DIFF
--- a/packages/docz-theme-default/src/components/shared/Sidebar/index.tsx
+++ b/packages/docz-theme-default/src/components/shared/Sidebar/index.tsx
@@ -33,6 +33,7 @@ const Wrapper = styled('div')`
   transition: transform 0.2s, background 0.3s;
   transform: translateX(${toggle});
   z-index: 100;
+  overflow: auto;
 
   ${p =>
     p.theme.mq({


### PR DESCRIPTION
### Description

I can't see my components when it reached the maximum screen size height
