### PR TITLE
[docz-theme-default] Remove color transparent on body

### DIFF
--- a/packages/docz-theme-default/src/styles/global.ts
+++ b/packages/docz-theme-default/src/styles/global.ts
@@ -18,10 +18,6 @@ injectGlobal`
     overflow: hidden;
   }
 
-  body {
-    color: transparent;
-  }
-
   html, body, #root {
     height: 100vh;
     min-height: 100vh;


### PR DESCRIPTION
### Description

Fix applied to docz-theme-default package

My components are displayed with a transparent text (especially all components using portals).
It's due to the style `color: transparent` set on `body` element.

I don't know why it was set like that, but I propose to remove it to have by default a visible text color for components using portals.

I hope it helps. Docz is a great tool ;)