### PR TITLE
Fix active port

### DIFF
--- a/packages/docz-core/src/bundlers/webpack/config.ts
+++ b/packages/docz-core/src/bundlers/webpack/config.ts
@@ -218,7 +218,7 @@ export const createConfig = (babelrc: BabelRC) => (
       {
         compilationSuccessInfo: {
           messages: [
-            `You application is running at ${protocol}://${hostname}:${port}`,
+            `Your application is running at ${protocol}://${hostname}:${port}`,
           ],
         },
       },

--- a/packages/docz-core/src/bundlers/webpack/config.ts
+++ b/packages/docz-core/src/bundlers/webpack/config.ts
@@ -40,7 +40,7 @@ export const createConfig = (babelrc: BabelRC) => (
   args: Args,
   env: Env
 ): Config => {
-  const { debug, host, port, protocol } = args
+  const { debug } = args
 
   const config = new Config()
   const isProd = env === 'production'
@@ -203,9 +203,6 @@ export const createConfig = (babelrc: BabelRC) => (
     },
   ])
 
-  const isLocalhost = host === '127.0.0.1' || host === '0.0.0.0'
-  const hostname = isLocalhost ? 'localhost' : host
-
   config.when(!debug && !isProd, cfg => {
     cfg.plugin('webpackbar').use(webpackBarPlugin, [
       {
@@ -217,9 +214,7 @@ export const createConfig = (babelrc: BabelRC) => (
     cfg.plugin('friendly-errors').use(friendlyErrors, [
       {
         compilationSuccessInfo: {
-          messages: [
-            `Your application is running at ${protocol}://${hostname}:${port}`,
-          ],
+          messages: [],
         },
       },
     ])


### PR DESCRIPTION
### Description

Addresses #40 

This PR changes the location of the friendlyErrors `compilationSuccessInfo` message, allowing it to report the actual running port, instead of what was supplied in the config.

### Screenshots

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/11514928/42128572-73f94a60-7c63-11e8-923f-7432578d8d3e.png) | ![image](https://user-images.githubusercontent.com/11514928/42128551-0b5c88be-7c63-11e8-8b47-96b59f3ab281.png)|