### PR TITLE
corrected css class for PropsTable 'default'-column header

### DIFF
--- a/packages/docz/src/components/PropsTable.tsx
+++ b/packages/docz/src/components/PropsTable.tsx
@@ -138,7 +138,7 @@ const BasePropsTable: SFC<PropsTable> = ({ of: component, components }) => {
             <Th className="PropsTable--property">Property</Th>
             <Th className="PropsTable--type">Type</Th>
             <Th className="PropsTable--required">Required</Th>
-            <Th className="PropsTable--description">Default</Th>
+            <Th className="PropsTable--default">Default</Th>
             <Th width="40%" className="PropsTable--description">
               Description
             </Th>


### PR DESCRIPTION
### Description

The 'default' column header in the PropsTable had a css class that's related to the 'description'-column. I've corrected this by giving the 'default'-column header a unique class.