### PR TITLE
fix(docz-core): use of src config in edit button link

### DIFF
--- a/packages/docz-core/src/Entries.tsx
+++ b/packages/docz-core/src/Entries.tsx
@@ -71,7 +71,7 @@ export class Entries {
   public repoUrl: string | null
 
   constructor(config: Config) {
-    this.repoUrl = repoInfo()
+    this.repoUrl = repoInfo(config.src)
     this.all = new Map()
     this.get = async () => this.getMap(config)
   }

--- a/packages/docz-core/src/utils/repo-info.ts
+++ b/packages/docz-core/src/utils/repo-info.ts
@@ -5,10 +5,11 @@ import findup from 'find-up'
 
 import * as paths from '../config/paths'
 
-export const repoInfo = (): string | null => {
+export const repoInfo = (src: string | './'): string | null => {
   try {
     const project = path.parse(findup.sync('.git')).dir
-    const relative = path.relative(project, paths.root)
+    const root = path.join(paths.root, src);
+    const relative = path.relative(project, root)
     const tree = path.join('/tree/master', relative)
     const pkg = fs.readJsonSync(paths.appPackageJson)
     const repo = getPkgRepo(pkg)


### PR DESCRIPTION
### Description

In version 0.9.2, when I have a `src` different from `./` in the `.doczrc.js` file, the edit button doesn't have the correct link address. The `src` is missing in the link.

**For example:**
With the following configuration:
```js
#.doczrc.js
export default {
  src: './src',
  port: 3001,
}
```
A mdx file in `myrepo/src/components/button/button.mdx`

Then the edit button will go to:
```
https://github.com/xxx/myrepo/components/button/button.mdx
```
instead of:
```
https://github.com/xxx/myrepo/src/components/button/button.mdx
```

**In this PR, I add the missing part of the link using the `src` config parameter.**