### PR TITLE
chore(docz-example-flow): fix scale and outline props

### DIFF
--- a/examples/flow/src/components/Button.jsx
+++ b/examples/flow/src/components/Button.jsx
@@ -71,7 +71,7 @@ export const Button = ({
   outline = false,
   children,
 }: ButtonProps) => (
-  <ButtonStyled scales={scales} kind={kind} outlint={outline}>
+  <ButtonStyled scale={scale} kind={kind} outline={outline}>
     {children}
   </ButtonStyled>
 )


### PR DESCRIPTION
### Description

Typos prevented distinguishing the sizes and outline styles in the flow example. I double-checked that no other Button examples have this issue

### Screenshots

| Before | After |
| ------ | ----- |
| ![before-sizes](https://user-images.githubusercontent.com/5553498/43993023-687317da-9d55-11e8-91de-7c6db6dd5925.png)| ![after-sizes](https://user-images.githubusercontent.com/5553498/43993025-6c380a92-9d55-11e8-96cf-05ce7a1b3d77.png) |
| ![before-outline](https://user-images.githubusercontent.com/5553498/43993027-8059374e-9d55-11e8-87e5-5e8b7ed88b2e.png) | ![after-outline](https://user-images.githubusercontent.com/5553498/43993030-83c38600-9d55-11e8-97eb-fb4a2b219de9.png) |
