### PR TITLE
fix(docz-core): writeApp before setting up the server and create db.json

### DIFF
--- a/packages/docz-core/src/Entries.ts
+++ b/packages/docz-core/src/Entries.ts
@@ -54,8 +54,10 @@ const writeAppFiles = async (config: Config, dev: boolean): Promise<void> => {
 
   await fs.remove(paths.rootJs)
   await fs.remove(paths.indexJs)
+  await fs.remove(paths.db)
   await touch(paths.rootJs, rawRootJs)
   await touch(paths.indexJs, rawIndexJs)
+  await touch(paths.db, "{}")
 }
 
 export type EntryMap = Record<string, EntryObj>

--- a/packages/docz-core/src/commands/dev.ts
+++ b/packages/docz-core/src/commands/dev.ts
@@ -22,6 +22,13 @@ export const dev = async (args: Config) => {
   )
 
   const newConfig = { ...config, websocketPort, hotPort, port }
+  try {
+    await Entries.writeApp(newConfig, true)
+  } catch(err) {
+    logger.fatal('Failed to process initialise your app:', err)
+    process.exit(1)
+  }
+
   const bundler = webpack(newConfig, env)
   const bundlerConfig = await bundler.getConfig(env)
   const server = await bundler.createServer(bundlerConfig)
@@ -37,7 +44,6 @@ export const dev = async (args: Config) => {
 
     await dataServer.init()
     await dataServer.listen()
-    await Entries.writeApp(newConfig, true)
   } catch (err) {
     logger.fatal('Failed to process your server:', err)
     process.exit(1)


### PR DESCRIPTION
### Description

Fix a regression introduced by the caching layer in [DataServer](https://github.com/pedronauck/docz/blob/715e4fbd1be9df688e1bfff3f56cfa5929e0e611/packages/docz-core/src/DataServer.ts#L42) trying to read `app/db.json` when starting a new project since the `.docz` folder doesn't exist until `writeApp` is called.

### Review

- [ ] Is moving `Entries.writeApp` right after `newConfig` is defined ok ([see change](https://github.com/dariocravero/docz/commit/b4f8bd5e750457347298829265a240e06e237480#diff-449dcfb7310b4c71a631746db5483224R26))?
- [ ] Is re-creating `db.json` ok ([see change](https://github.com/dariocravero/docz/commit/b4f8bd5e750457347298829265a240e06e237480#diff-f1850003a632feff320b25867aea4c7eR57))?

### Pre-merge checklist

N/A?

### Screenshots

N/A