### PR TITLE
fix(example-typescript): fix dependencies

### DIFF
--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "docz": "^0.10.2",
+    "docz-core": "^0.10.2",
     "emotion": "^9.2.6",
     "react": "^16.4.2",
     "react-dom": "^16.4.2",


### PR DESCRIPTION
### Description

fix example-typescript dependencies.

the docz-core is missing.