### PR TITLE
fix(docz-theme-default): fix mobile menu peaking

### DIFF
--- a/packages/docz-theme-default/src/components/shared/Sidebar/Hamburguer.tsx
+++ b/packages/docz-theme-default/src/components/shared/Sidebar/Hamburguer.tsx
@@ -61,7 +61,7 @@ const ToggleButton = styled('button')`
   width: 33px;
   height: 30px;
   top: ${(p: OpenProps) => (p.opened ? '3px' : '2px')};
-  right: ${(p: OpenProps) => (p.opened ? '-39px' : '0px')};
+  right: ${(p: OpenProps) => (p.opened ? '-39px' : '-28px')};
   transform: translateX(${translateX}) translateY(${translateY});
   transition: transform 0.3s;
   outline: none;

--- a/packages/docz-theme-default/src/components/shared/Sidebar/index.tsx
+++ b/packages/docz-theme-default/src/components/shared/Sidebar/index.tsx
@@ -20,7 +20,7 @@ interface WrapperProps {
   theme?: any
 }
 
-const toggle = (p: WrapperProps) => (p.opened && !p.desktop ? '-90%' : '0')
+const toggle = (p: WrapperProps) => (p.opened && !p.desktop ? '-100%' : '0')
 
 const background = (p: WrapperProps) =>
   toggle(p) !== '0' ? 'transparent' : p.theme.docz.colors.sidebarBg


### PR DESCRIPTION
### Description

On mobile, the side menu is "peaking". Some elements are not hidden far enough. See the screenshot below.

Look to the far left. The caret icon and the dashed border are peaking from the menu.

### Review

After the changes, I ran the basic example across the big 4 browsers to ensure fix consistency.

### Screenshots

| Before | After |
| ------ | ----- |
| ![screen shot 2018-08-28 at 2 11 30 pm](https://user-images.githubusercontent.com/8016033/44753161-ffb8fb80-aad1-11e8-9f48-98d47e22e3c5.png) | ![screen shot 2018-08-28 at 2 27 08 pm](https://user-images.githubusercontent.com/8016033/44753175-11020800-aad2-11e8-8a8d-703670b3a16e.png)