### PR TITLE
fix(docz-core): remove https option and fix message

### DIFF
--- a/packages/docz-core/src/bundlers/webpack/config.ts
+++ b/packages/docz-core/src/bundlers/webpack/config.ts
@@ -42,7 +42,7 @@ const uglify = new UglifyJs({
 export const createConfig = (args: Args, env: Env) => async (
   babelrc: BabelRC
 ): Promise<Configuration> => {
-  const { debug, host, port, protocol } = args
+  const { debug, host, port } = args
 
   const config = new Config()
   const isProd = env === 'production'
@@ -227,7 +227,7 @@ export const createConfig = (args: Args, env: Env) => async (
       {
         compilationSuccessInfo: {
           messages: [
-            `Your application is running at ${protocol}://${hostname}:${port}`,
+            `Your application is running at http://${hostname}:${port}`,
           ],
         },
       },

--- a/packages/docz-core/src/commands/args.ts
+++ b/packages/docz-core/src/commands/args.ts
@@ -51,7 +51,6 @@ export interface Argv {
   debug: boolean
   typescript: boolean
   propsParser: boolean
-  protocol: string
   host: string
   port: number
   websocketPort: number
@@ -147,10 +146,6 @@ export const args = (env: Env) => (yargs: any) => {
   yargs.positional('debug', {
     type: 'boolean',
     default: getEnv('docz.debug', false),
-  })
-  yargs.positional('protocol', {
-    type: 'string',
-    default: getEnv('docz.https', true) ? 'https' : 'http',
   })
   yargs.positional('host', {
     type: 'string',


### PR DESCRIPTION
Fix #310 

![image](https://user-images.githubusercontent.com/2096216/45328253-85f12b00-b531-11e8-9b56-abd34ebfd49b.png)

At least until a cert could be used: https://github.com/webpack-contrib/webpack-serve#optionshttps