### PR TITLE
fix(example-typescript)/add-typescript-to-devDependencies

### DIFF
--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -15,6 +15,7 @@
     "react-emotion": "^9.2.8"
   },
   "devDependencies": {
-    "babel-plugin-emotion": "^9.2.8"
+    "babel-plugin-emotion": "^9.2.8",
+    "typescript": "^3.0.3"
   }
 }


### PR DESCRIPTION
### Description

Add `typescript` to `devDependencies` under `examples/typescript` so that within this folder after run `yarn install` then `yarn dev`, you should be able to see the docz site at `localhost:3000`. Now it throws error `Error: Cannot find module 'typescript'`.