### PR TITLE
feat(docz): ensure PropTable follow propTypes order

### DIFF
--- a/packages/docz/src/components/PropsTable.tsx
+++ b/packages/docz/src/components/PropsTable.tsx
@@ -129,7 +129,8 @@ const BasePropsTable: SFC<PropsTable> = ({ of: component, components }) => {
         </Thead>
         <Tbody>
           {props &&
-            Object.keys(props).map((name: string) => {
+            component.propTypes &&
+            Object.keys(component.propTypes).map((name: string) => {
               const prop = props[name]
 
               if (!prop.flowType && !prop.type) return null


### PR DESCRIPTION
### Description

The `PropTable` component doesn't follow the order defined by `propTypes`. I described everything under this [issue](https://github.com/pedronauck/docz/issues/379).

### How 

I used `Object.keys` on `component.propTypes` instead of the prop variable. I don't know if it's the best approach. 