### PR TITLE
Conditionally include the Description column for the PropsTable component

### DIFF
--- a/examples/basic/src/components/Alert.jsx
+++ b/examples/basic/src/components/Alert.jsx
@@ -20,6 +20,7 @@ const AlertStyled = styled('div')`
 export const Alert = props => <AlertStyled {...props} />
 
 Alert.propTypes = {
+  /** `info`, `positive`, `negative`, or `warning` */
   kind: t.oneOf(['info', 'positive', 'negative', 'warning']),
 }
 

--- a/packages/docz-theme-default/src/styles/index.ts
+++ b/packages/docz-theme-default/src/styles/index.ts
@@ -58,7 +58,8 @@ export const styles = {
     lineHeight: 1.8,
   },
   table: {
-    overflowY: ['hidden', 'hidden', 'hidden', 'initial'],
+    overflowY: 'hidden',
+    overflowX: ['initial', 'initial', 'initial', 'hidden'],
     display: ['block', 'block', 'block', 'table'],
     width: '100%',
     marginBottom: [20, 40],

--- a/packages/docz/src/components/PropsTable.tsx
+++ b/packages/docz/src/components/PropsTable.tsx
@@ -138,10 +138,20 @@ const BasePropsTable: SFC<PropsTable> = ({ of: component, components }) => {
                   <Td>{name}</Td>
                   <Td>{getPropType(prop, Tooltip)}</Td>
                   <Td>{String(prop.required)}</Td>
-                  <Td>
-                    {prop.defaultValue &&
-                      prop.defaultValue.value.replace(/\'/g, '')}
-                  </Td>
+                  {!prop.defaultValue ? (
+                    <Td>
+                      <em>[No Default]</em>
+                    </Td>
+                  ) : (
+                    <Td>
+                      {prop.defaultValue.value === "''" ? (
+                        <em>[Empty String]</em>
+                      ) : (
+                        prop.defaultValue &&
+                        prop.defaultValue.value.replace(/\'/g, '')
+                      )}
+                    </Td>
+                  )}
                   <Td>{prop.description && prop.description}</Td>
                 </Tr>
               )

--- a/packages/docz/src/components/PropsTable.tsx
+++ b/packages/docz/src/components/PropsTable.tsx
@@ -121,7 +121,7 @@ const BasePropsTable: SFC<PropsTable> = ({ of: component, components }) => {
 
   return (
     <Fragment>
-      <Table className="PropsTable" data-was-description-excluded={includeDescription ? 'false' : 'true'}>
+      <Table className="PropsTable">
         <Thead>
           <Tr>
             <Th className="PropsTable--property">Property</Th>

--- a/packages/docz/src/components/PropsTable.tsx
+++ b/packages/docz/src/components/PropsTable.tsx
@@ -105,6 +105,12 @@ const BasePropsTable: SFC<PropsTable> = ({ of: component, components }) => {
     return null
   }
 
+  const includeDescription: boolean = Object.keys(props).some(
+    (name: string) =>
+      props[name] &&
+      typeof props[name].description !== 'undefined' &&
+      props[name].description !== ''
+  )
   const Table = components.table || 'table'
   const Thead = components.thead || 'thead'
   const Tr = components.tr || 'tr'
@@ -115,16 +121,18 @@ const BasePropsTable: SFC<PropsTable> = ({ of: component, components }) => {
 
   return (
     <Fragment>
-      <Table className="PropsTable">
+      <Table className="PropsTable" data-was-description-excluded={includeDescription ? 'false' : 'true'}>
         <Thead>
           <Tr>
             <Th className="PropsTable--property">Property</Th>
             <Th className="PropsTable--type">Type</Th>
             <Th className="PropsTable--required">Required</Th>
             <Th className="PropsTable--default">Default</Th>
-            <Th width="40%" className="PropsTable--description">
-              Description
-            </Th>
+            {includeDescription && (
+              <Th width="40%" className="PropsTable--description">
+                Description
+              </Th>
+            )}
           </Tr>
         </Thead>
         <Tbody>
@@ -142,7 +150,9 @@ const BasePropsTable: SFC<PropsTable> = ({ of: component, components }) => {
                     {prop.defaultValue &&
                       prop.defaultValue.value.replace(/\'/g, '')}
                   </Td>
-                  <Td>{prop.description && prop.description}</Td>
+                  {includeDescription && (
+                    <Td>{prop.description && prop.description}</Td>
+                  )}
                 </Tr>
               )
             })}


### PR DESCRIPTION
### Description
When generating docs for an internal project with the window made narrow. I was running out of space for the `PropsTable` component when no descriptions were present for that component. It didn't appear that there was a flag available for this and after thinking about it I decided this wasn't necessary since it could be inferred if this should be included.

### Review

- [ ] Code Review

### Screenshots

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/1476753/46381349-7fa32a00-c66b-11e8-8abf-9261b3fcd4b6.png) | ![image](https://user-images.githubusercontent.com/1476753/46381367-8d58af80-c66b-11e8-8c74-df7cb9f5cb78.png) |
| Before even if a _Description_ was never used the column displayed | Now if none of the _Props_ provide a description comment the column is removed |

This was tested and appears to be functional based on all the checks specified in the contributing guide.