### PR TITLE
fix(docz-theme-default): text alignment in table thead

### DIFF
--- a/packages/docz-theme-default/src/components/ui/Table.tsx
+++ b/packages/docz-theme-default/src/components/ui/Table.tsx
@@ -32,7 +32,6 @@ const TableStyled = styled('table')`
   }
 
   & thead th {
-    text-align: left;
     font-weight: 400;
     padding: 20px 20px;
 

--- a/packages/docz/src/components/PropsTable.tsx
+++ b/packages/docz/src/components/PropsTable.tsx
@@ -1,9 +1,19 @@
 import * as React from 'react'
-import { Fragment, SFC, ComponentType } from 'react'
+import { CSSProperties, Fragment, SFC, ComponentType } from 'react'
 import { withMDXComponents } from '@mdx-js/tag/dist/mdx-provider'
 import capitalize from 'capitalize'
 
 import { humanize } from '../utils/humanize-prop'
+
+export interface StylesMap {
+  [s: string]: CSSProperties
+}
+
+const styles: StylesMap = {
+  thead: {
+    textAlign: 'left'
+  },
+}
 
 export interface EnumValue {
   value: string
@@ -116,7 +126,7 @@ const BasePropsTable: SFC<PropsTable> = ({ of: component, components }) => {
   return (
     <Fragment>
       <Table className="PropsTable">
-        <Thead>
+        <Thead style={styles.thead}>
           <Tr>
             <Th className="PropsTable--property">Property</Th>
             <Th className="PropsTable--type">Type</Th>


### PR DESCRIPTION
### Description

A bug was found that do persist `text-align: left;` in all `thead th` tables, probably because of PropsTable.

Fixes #342 

### Review

- [x] Check code implementation

### Screenshots

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/5435657/46813416-041d3900-cd4d-11e8-9d73-e4762ab2ad11.png) | ![image](https://user-images.githubusercontent.com/5435657/46813393-fc5d9480-cd4c-11e8-92a5-521c167dfdc2.png) |