### PR TITLE
fix(docz-theme-default): prop table header background was overflowing

### DIFF
--- a/packages/docz-theme-default/src/styles/index.ts
+++ b/packages/docz-theme-default/src/styles/index.ts
@@ -58,7 +58,8 @@ export const styles = {
     lineHeight: 1.8,
   },
   table: {
-    overflowY: ['hidden', 'hidden', 'hidden', 'initial'],
+    overflowY: 'hidden',
+    overflowX: ['initial', 'initial', 'initial', 'hidden'],
     display: ['block', 'block', 'block', 'table'],
     width: '100%',
     marginBottom: [20, 40],


### PR DESCRIPTION
The header background was peeking over the border-radius of the table, only on the largest breakpoint. In my testing, it seems like you want to leave overflow-x there for small screens.

<img width="207" alt="screen shot 2018-10-20 at 12 01 12 am" src="https://user-images.githubusercontent.com/438545/47252545-8bc51080-d3fb-11e8-96d8-9f44aad0e3f9.png">

### Screenshots

Before:
<img width="1475" alt="screen shot 2018-10-19 at 9 36 42 pm" src="https://user-images.githubusercontent.com/438545/47252504-ffb2e900-d3fa-11e8-8c6a-360fcee8a7c4.png"> 

After:
<img width="1475" alt="screen shot 2018-10-19 at 9 36 29 pm" src="https://user-images.githubusercontent.com/438545/47252510-0d686e80-d3fb-11e8-9459-0ef678a3a8bb.png">

