### PR TITLE
Updates the PropsTable to render '[Empty String]' instead of nothing.

### DIFF
--- a/packages/docz/src/components/PropsTable.tsx
+++ b/packages/docz/src/components/PropsTable.tsx
@@ -138,14 +138,20 @@ const BasePropsTable: SFC<PropsTable> = ({ of: component, components }) => {
                   <Td>{name}</Td>
                   <Td>{getPropType(prop, Tooltip)}</Td>
                   <Td>{String(prop.required)}</Td>
-                  <Td>
-                    {prop.defaultValue && prop.defaultValue.value === "''" ? (
-                      <em>[Empty String]</em>
-                    ) : (
-                      prop.defaultValue &&
-                      prop.defaultValue.value.replace(/\'/g, '')
-                    )}
-                  </Td>
+                  {!prop.defaultValue ? (
+                    <Td>
+                      <em>[No Default]</em>
+                    </Td>
+                  ) : (
+                    <Td>
+                      {prop.defaultValue.value === "''" ? (
+                        <em>[Empty String]</em>
+                      ) : (
+                        prop.defaultValue &&
+                        prop.defaultValue.value.replace(/\'/g, '')
+                      )}
+                    </Td>
+                  )}
                   <Td>{prop.description && prop.description}</Td>
                 </Tr>
               )

--- a/packages/docz/src/components/PropsTable.tsx
+++ b/packages/docz/src/components/PropsTable.tsx
@@ -139,8 +139,12 @@ const BasePropsTable: SFC<PropsTable> = ({ of: component, components }) => {
                   <Td>{getPropType(prop, Tooltip)}</Td>
                   <Td>{String(prop.required)}</Td>
                   <Td>
-                    {prop.defaultValue &&
-                      prop.defaultValue.value.replace(/\'/g, '')}
+                    {prop.defaultValue && prop.defaultValue.value === "''" ? (
+                      <em>[Empty String]</em>
+                    ) : (
+                      prop.defaultValue &&
+                      prop.defaultValue.value.replace(/\'/g, '')
+                    )}
                   </Td>
                   <Td>{prop.description && prop.description}</Td>
                 </Tr>


### PR DESCRIPTION
### Description

Adds _`[Empty String]`_ or _`[No Default]`_ to the "Default" column depending on the prop. 

### Screenshots
#### Before
__If it wasn't for the prop name...which prop had no default and which one is an empty string?__
![image](https://user-images.githubusercontent.com/1476753/47596859-4abe8600-d93e-11e8-8864-a1801fe09a98.png)

#### After
![image](https://user-images.githubusercontent.com/1476753/47596967-5cecf400-d93f-11e8-91aa-24abda70cb70.png)


