### PR TITLE
fix(docz-theme-default): rename playground container to avoid conflicts

### DIFF
--- a/packages/docz-theme-default/src/components/ui/Render/index.tsx
+++ b/packages/docz-theme-default/src/components/ui/Render/index.tsx
@@ -388,13 +388,13 @@ export class Render extends Component<RenderComponentProps, RenderState> {
 
   private transformCode(code: string): string {
     return `
-      const App = ({ children }) => (
+      const DoczApp = ({ children }) => (
         <React.Fragment>
           {children && typeof children === 'function' ? children() : children}
         </React.Fragment>
       )
 
-      render(<App>${code}</App>)
+      render(<DoczApp>${code}</DoczApp>)
     `
   }
 


### PR DESCRIPTION
### Description

Solves issue: https://github.com/pedronauck/docz/issues/426
I renamed playground container to avoid conflicts with components named `App`.

<!-- ### Review

-- [ ] 

### Pre-merge checklist

- [ ] ... -->
