### PR TITLE
fix(docz-theme-default): adjust z-index of menu

### DIFF
--- a/packages/docz-theme-default/src/components/shared/Sidebar/index.tsx
+++ b/packages/docz-theme-default/src/components/shared/Sidebar/index.tsx
@@ -36,7 +36,7 @@ const Wrapper = styled('div')`
   min-height: 100vh;
   background: ${sidebarBg};
   transition: transform 0.2s, background 0.3s;
-  z-index: 100;
+  z-index: 1000;
   ${position};
   ${get('styles.sidebar')};
 


### PR DESCRIPTION
Fixes: 

![127 0 0 1_3000_src-button iphone 5_se](https://user-images.githubusercontent.com/105919/48521923-89968a80-e8b1-11e8-9473-dd46450c7aa3.png)
