### PR TITLE
Resolve react warnings in ErrorReporter

### DIFF
--- a/packages/docz/src/components/ErrorBoundary.tsx
+++ b/packages/docz/src/components/ErrorBoundary.tsx
@@ -30,6 +30,8 @@ const styles: StylesMap = {
   stack: {
     display: 'flex',
     flexDirection: 'column',
+    marginBottom: '1em',
+    marginTop: '1em',
   },
 }
 
@@ -40,11 +42,11 @@ const ErrorReporter: SFC<ErrorBoundaryRP> = ({ error, componentStack }) => (
       {error && <div>{error.message}</div>}
       <h2 style={styles.subtitle}>Stack trace</h2>
       {componentStack && (
-        <p style={styles.stack}>
+        <div style={styles.stack}>
           {componentStack.split('\n').map(str => (
-            <div>{str}</div>
+            <div key={str}>{str}</div>
           ))}
-        </p>
+        </div>
       )}
     </div>
   </div>


### PR DESCRIPTION
### Description

Getting errors from the `ErrorReporter` makes it difficult to see the actual error that's occurring. This PR resolves those errors.

- `<div>` cannot appear as a descendant of `<p>`
- Each child in an array or iterator should have a unique "key" prop

### Screenshots

| Before | After |
| ------ | ----- |
| Image  | Image |
![image](https://user-images.githubusercontent.com/2730833/48876292-65a6ec00-ee51-11e8-86a6-cfd5a6df3806.png)
