### PR TITLE
fix(docz-core): #485 correct koa mounting path on windows systems

### DIFF
--- a/packages/docz-core/src/webpack/devserver.ts
+++ b/packages/docz-core/src/webpack/devserver.ts
@@ -43,7 +43,7 @@ export const devServerConfig = (
       app.use(range)
 
       if (fs.existsSync(publicDir)) {
-        app.use(mount(path.join(args.base, '/public'), serveStatic(publicDir)))
+        app.use(mount(path.posix.join(args.base, '/public'), serveStatic(publicDir)))
       }
 
       app.use(


### PR DESCRIPTION
### Description

See https://github.com/pedronauck/docz/issues/485 .

Examples appear unchanged. Might be good to check on a macOS machine as well.