### PR TITLE
fixes #494

### DIFF
--- a/packages/docz-theme-default/src/components/ui/Page.tsx
+++ b/packages/docz-theme-default/src/components/ui/Page.tsx
@@ -47,8 +47,8 @@ const EditPage = styled(ButtonLink.withComponent('a'))`
   ${p =>
     p.theme.docz.mq({
       visibility: ['hidden', 'hidden', 'visible'],
-      top: [0, -60, 10],
-      right: [0, 0, 32],
+      top: [0, -60, 32],
+      right: [0, 0, 40],
     })};
 `
 
@@ -73,7 +73,7 @@ export const Page: SFC<PageProps> = ({
 
   return (
     <ThemeConfig>
-      {({ repository, ...config }) => (
+      {({ repository, ...config }: { repository: string }) => (
         <Main config={config}>
           {repository && <GithubLink repository={repository} />}
           {!fullpage && <Sidebar />}

--- a/packages/docz-theme-default/src/index.tsx
+++ b/packages/docz-theme-default/src/index.tsx
@@ -18,7 +18,7 @@ const mergeTheme = (config: any) => (old: any) => ({
 
 const Theme = () => (
   <ThemeConfig>
-    {config => (
+    {(config: object) => (
       <ThemeProvider theme={mergeTheme(config)}>
         <DocPreview
           components={{


### PR DESCRIPTION
### Description

just a small visual fix. Now, the right upper corner looks slightly nicer with the github SVG not overlapping the button.

### Screenshots

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/1305378/49670885-61401d00-fa66-11e8-9f02-ee701d07e53c.png)  | ![image](https://user-images.githubusercontent.com/1305378/49688577-b9cdf380-fb14-11e8-9fa3-8d3bdfbffa66.png) |