### PR TITLE
fix(docz-theme-default): refresh editor after it's mounted (#406)

### DIFF
--- a/packages/docz-theme-default/src/components/ui/Editor/index.tsx
+++ b/packages/docz-theme-default/src/components/ui/Editor/index.tsx
@@ -103,7 +103,7 @@ export class Editor extends Component<EditorProps, EditorState> {
     const editorProps = (config: any) => ({
       value: this.state.code,
       className: editorClassName,
-      editorDidMount: this.removeLastLine,
+      editorDidMount: this.onEditorDidMount,
       onBeforeChange: this.handleChange,
       options: {
         ...options,
@@ -122,6 +122,13 @@ export class Editor extends Component<EditorProps, EditorState> {
         <Actions>{actions || <ClipboardAction content={code} />}</Actions>
       </Wrapper>
     )
+  }
+
+  private onEditorDidMount = (editor: any) => {
+    if (editor) {
+      this.removeLastLine(editor)
+      editor.refresh()
+    }
   }
 
   private removeLastLine = (editor: any) => {


### PR DESCRIPTION
### Description

Close #406 

### Screenshots

#### Before

![docz-before](https://user-images.githubusercontent.com/32722363/49917070-016fc900-fee1-11e8-844d-10f29bd93433.gif)

#### After

![docz-after](https://user-images.githubusercontent.com/32722363/49917073-0765aa00-fee1-11e8-8b32-87350bf4eda9.gif)
