### PR TITLE
feat: use NODE_PATH for root directory(fix #396)

### DIFF
--- a/packages/docz-core/src/config/env.ts
+++ b/packages/docz-core/src/config/env.ts
@@ -11,11 +11,15 @@ const populateNodePath = () => {
   // Otherwise, we risk importing Node.js core modules into an app instead of Webpack shims.
   // https://github.com/facebook/create-react-app/issues/1023#issuecomment-265344421
   // We also resolve them to make sure all tools using them work consistently.
-  return (envDotProp.get('node.path') || '')
-    .split(path.delimiter)
-    .filter((folder: any) => folder && !path.isAbsolute(folder))
-    .map((folder: any) => path.resolve(root, folder))
-    .join(path.delimiter)
+  envDotProp.set(
+    'node.path',
+    envDotProp
+      .get('node.path', '')
+      .split(path.delimiter)
+      .filter((folder: any) => folder && !path.isAbsolute(folder))
+      .map((folder: any) => path.resolve(root, folder))
+      .join(path.delimiter)
+  )
 }
 
 const configDotEnv = () => {

--- a/packages/docz-core/src/webpack/config.ts
+++ b/packages/docz-core/src/webpack/config.ts
@@ -8,6 +8,7 @@ import friendlyErrors from 'friendly-errors-webpack-plugin'
 import manifestPlugin from 'webpack-manifest-plugin'
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer'
 import * as TerserPlugin from 'terser-webpack-plugin'
+import envDotProp from 'env-dot-prop'
 
 import * as loaders from './loaders'
 import * as paths from '../config/paths'
@@ -161,6 +162,13 @@ export const createConfig = (args: Args, env: Env) => async (
     .add('node_modules')
     .add(srcPath)
     .add(paths.root)
+    .merge([
+      envDotProp
+        .get('node.path')
+        .split(path.delimiter)
+        .filter(Boolean),
+    ])
+
 
   config.resolveLoader
     .set('symlinks', true)


### PR DESCRIPTION


### Description

Add a babel plugin to use NODE_PATH for root

### Review

- [ ] Check the copy
- [ ] ...
- [ ] ...

### Pre-merge checklist

- [ ] ...
- [ ] ...

### Screenshots

| Before | After |
| ------ | ----- |
| Image  | Image |