### PR TITLE
fix(docz-core): turn off htmlMinifier when loading from templates

### DIFF
--- a/packages/docz-core/src/Entries.ts
+++ b/packages/docz-core/src/Entries.ts
@@ -26,8 +26,8 @@ const writeAppFiles = async (config: Config, dev: boolean): Promise<void> => {
   const onPreRenders = props('onPreRender')
   const onPostRenders = props('onPostRender')
 
-  const root = await compiled(fromTemplates('root.tpl.js'))
-  const js = await compiled(fromTemplates('index.tpl.js'))
+  const root = await compiled(fromTemplates('root.tpl.js'), { minimize: false })
+  const js = await compiled(fromTemplates('index.tpl.js'), { minimize: false })
   const websocketUrl = `ws://${config.websocketHost}:${config.websocketPort}`
 
   const rawRootJs = root({


### PR DESCRIPTION
### Description
Fix #395 
When running the `NODE_ENV=production docz build`, htmlMinifier was turned on to load the template file in docz-core, causing the jsx was minimized. For etc, `<Theme />` become `<Theme >`. Eventually, resulting an error when passing to the prettier to be format. 

### Pre-merge checklist

- [X] Ensure `NODE_ENV=production docz build` ran successfully in all the examples
- [X] ran `yarn run fix` 

### Screenshots

| Before |
| ------ | 
|![image](https://user-images.githubusercontent.com/43637878/50068866-83723180-0202-11e9-9cfd-675fd87af705.png)|

|After|
| ------ | 
|![image](https://user-images.githubusercontent.com/43637878/50069089-76097700-0203-11e9-96eb-c19ecd4b0195.png)|