### PR TITLE
fix: escape ${} for template string in playground

### DIFF
--- a/packages/docz-utils/src/jsx.ts
+++ b/packages/docz-utils/src/jsx.ts
@@ -27,6 +27,7 @@ export const sanitizeCode = (code: string) => {
     .trim()
     .replace(/'/g, `\\'`)
     .replace(/`/g, '\\`')
+    .replace(/\${.*}/g, (match: string) => `\\${match}`)
 }
 
 export const componentName = (value: any) => {


### PR DESCRIPTION
replace `${` with` \${}`

### Description

Fix #312: escape template string