### PR TITLE
Remove ownNodeModules & appNodeModules from config resolvers

### DIFF
--- a/packages/docz-core/src/webpack/config.ts
+++ b/packages/docz-core/src/webpack/config.ts
@@ -102,8 +102,6 @@ export const createConfig = (args: Args, env: Env) => async (
   config.resolve.alias.set('react-native$', 'react-native-web')
 
   config.resolve.modules
-    .add(paths.ownNodeModules)
-    .add(paths.appNodeModules)
     .add('node_modules')
     .add(srcPath)
     .add(paths.root)
@@ -117,8 +115,6 @@ export const createConfig = (args: Args, env: Env) => async (
   config.resolveLoader
     .set('symlinks', true)
     .modules // prioritize our own
-    .add(paths.ownNodeModules)
-    .add(paths.appNodeModules)
     .add('node_modules')
     .add(paths.root)
 


### PR DESCRIPTION
### Description

I'm not too sure if we need to specify `ownNodeModules` & `appNodeModules` when webpack should scan for `node_modules` by looking at the current directory as well as its relative parents (i.e. `./node_modules`, `../node_modules`, `../../node_modules`, etc). Was there any reasoning why it was done like this though? Correct me if I'm wrong!

I was having an issue where my app was depending on `package-a@1.0.0`, however, one of my app's dependants depended on `package-a@2.0.0`, however it was resolving to `package-a@1.0.0` (the app's `node_modules`). 
