### PR TITLE
fix: scroll to anchor if url has hash

### DIFF
--- a/packages/docz/src/components/AsyncComponent.tsx
+++ b/packages/docz/src/components/AsyncComponent.tsx
@@ -23,6 +23,7 @@ export class AsyncComponent extends Component<Props, State> {
 
   public componentDidMount(): void {
     this.fetch()
+    this.scrollToAnchor()
   }
 
   public render(): ReactNode {
@@ -53,5 +54,17 @@ export class AsyncComponent extends Component<Props, State> {
         })
       }
     }
+  }
+
+  private scrollToAnchor(): void {
+    setTimeout(() => {
+      if (location.hash) {
+        const id: string = location.hash.substring(1)
+        const el: HTMLElement | null = document.getElementById(id)
+        if (el) {
+          el.scrollIntoView()
+        }
+      }
+    }, 0)
   }
 }


### PR DESCRIPTION
fix #282 
add a function in AsyncComponent to perform scrollIntoView in cDM

It doesn't work now because browser perform scroll to anchor when DOM is ready, and because of the async component, anchor would not be loaded into DOM yet. So I add a function in cDM lifecycle to check if we have hash in url, perform scroll to anchor.