### PR TITLE
fix: wrapper property is ignored in <Playground>

### DIFF
--- a/packages/docz-theme-default/src/components/ui/Render/index.tsx
+++ b/packages/docz-theme-default/src/components/ui/Render/index.tsx
@@ -1,4 +1,4 @@
-import { SFC, Fragment, Component } from 'react'
+import { SFC, Fragment, Component, ComponentType } from 'react'
 import { RenderComponentProps, ThemeConfig } from 'docz'
 import { LiveProvider, LiveError, LivePreview } from 'react-live'
 import { css, jsx } from '@emotion/core'
@@ -63,7 +63,7 @@ const PreviewWrapper = styled('div')<OverlayProps>`
   min-height: ${whenFullscreen('198px', 'auto')};
 `
 
-const StyledPreview = styled(LivePreview)`
+const StyledPreviewWrapper = styled('div')`
   position: relative;
   box-sizing: border-box;
   width: 100%;
@@ -259,6 +259,10 @@ class RenderBase extends Component<RenderProps, RenderState> {
     }
   }
 
+  get userWrapper(): ComponentType<any> {
+    return this.props.wrapper || Fragment
+  }
+
   public render(): JSX.Element {
     const { className, style, scope } = this.props
     const { fullscreen, showEditor } = this.state
@@ -280,7 +284,11 @@ class RenderBase extends Component<RenderProps, RenderState> {
           <Resizable {...this.resizableProps}>
             <Wrapper full={fullscreen}>
               <PreviewWrapper full={fullscreen}>
-                <StyledPreview className={className} style={style} />
+                <StyledPreviewWrapper>
+                  <this.userWrapper>
+                    <LivePreview className={className} style={style} />
+                  </this.userWrapper>
+                </StyledPreviewWrapper>
                 <StyledError />
               </PreviewWrapper>
               {this.actions}

--- a/packages/docz/src/components/Playground.tsx
+++ b/packages/docz/src/components/Playground.tsx
@@ -33,7 +33,8 @@ const BasePlayground: SFC<PlaygroundProps> = ({
   return (
     <components.render
       {...props}
-      component={Wrapper ? <Wrapper>{children}</Wrapper> : children}
+      component={children}
+      wrapper={Wrapper}
       scope={__scope}
       position={__position}
       code={__code}


### PR DESCRIPTION
### Description

Fix wrapper property being ignored down the line the renderer of the default template.

I have changed the wrapping in the default theme renderer a bit to make sure that the wrapper is applied as close to the renderer playground as possible. This is specifically done to make sure the wrapper can reset all styles and there won't be any default styles defined inside the wrapper.

### BREAKING CHANGE
This changes the behaviour of \<Playground> in such way that instead of \<Playground> applying the wrapper, it is now the responsibility of the renderer to apply the wrapper. 
