### PR TITLE
Move Prettier from dependencies to devDependencies in docz-utils

### DIFF
--- a/packages/docz-utils/package.json
+++ b/packages/docz-utils/package.json
@@ -40,7 +40,6 @@
     "jsx-ast-utils": "^2.0.1",
     "lodash.flatten": "^4.4.0",
     "lodash.get": "^4.4.2",
-    "prettier": "^1.15.3",
     "remark-frontmatter": "^1.3.1",
     "remark-parse": "^6.0.2",
     "remark-parse-yaml": "^0.0.1",
@@ -53,5 +52,8 @@
     "unist-util-find": "^1.0.1",
     "unist-util-is": "^2.1.2",
     "unist-util-visit": "^1.4.0"
+  },
+  "devDependencies": {
+    "prettier": "^1.15.3"
   }
 }


### PR DESCRIPTION
Running `yarn why prettier` in my project, I noticed that Prettier is hoisted from `docz-plugin-css#docz-core#docz-utils#prettier`.  It should be moved to `devDependencies` if it's only used in scripts. Other docz packages might be worth checking too.