### PR TITLE
fix: extend sidebar to the bottom of the page

### DIFF
--- a/packages/docz-theme-default/src/components/shared/Sidebar/index.tsx
+++ b/packages/docz-theme-default/src/components/shared/Sidebar/index.tsx
@@ -62,6 +62,7 @@ const Content = styled('div')`
   min-width: 280px;
   height: 100%;
   max-height: 100vh;
+  background: ${sidebarBg};
 `
 
 const Menus = styled('nav')`


### PR DESCRIPTION
### Description

Extends the sidebar on the default theme to the bottom of the page. Previously when scrolling down, the sidebar's background color would not display below the scroll point.

### Screenshots

| Before | After |
| ------ | ----- |
| ![screen shot 2019-01-25 at 11 12 30](https://user-images.githubusercontent.com/700308/51739697-6434b280-2092-11e9-8e42-3f95979c05f3.png) | ![screen shot 2019-01-25 at 11 12 52](https://user-images.githubusercontent.com/700308/51739714-7151a180-2092-11e9-8feb-6cfb911e1e2b.png) |