### PR TITLE
Fix/issue#528 Serve correct public folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.13.7](https://github.com/pedronauck/docz/compare/v0.13.6...v0.13.7) (2018-12-26)
+
+**Note:** Version bump only for package docz
+
+
+
+
+
 ## [0.13.6](https://github.com/pedronauck/docz/compare/v0.13.5...v0.13.6) (2018-12-26)
 
 

--- a/README.md
+++ b/README.md
@@ -29,14 +29,6 @@
   </a>
 </p>
 
-## 🙌🏻 &nbsp; Sponsors
-
-Thanks for all people that support us 🙏🏻
-
-<a href="https://impulso.work" target="_blank">
-  <img src="https://cdn-std.dprcdn.net/files/acc_649651/OosgCe" width="60">
-</a>
-
 ## 🎩 &nbsp; Features
 
 - 🧘 **Zero config and easy.** Don't worry about complex configurations steps.

--- a/examples/basic/CHANGELOG.md
+++ b/examples/basic/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.13.7](https://github.com/pedronauck/docz/compare/v0.13.6...v0.13.7) (2018-12-26)
+
+**Note:** Version bump only for package docz-example-basic
+
+
+
+
+
 ## [0.13.6](https://github.com/pedronauck/docz/compare/v0.13.5...v0.13.6) (2018-12-26)
 
 **Note:** Version bump only for package docz-example-basic

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docz-example-basic",
-  "version": "0.13.6",
+  "version": "0.13.7",
   "license": "MIT",
   "scripts": {
     "dev": "docz dev",
@@ -15,6 +15,6 @@
   },
   "devDependencies": {
     "babel-plugin-emotion": "^10.0.5",
-    "docz": "^0.13.6"
+    "docz": "^0.13.7"
   }
 }

--- a/examples/flow/CHANGELOG.md
+++ b/examples/flow/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.13.7](https://github.com/pedronauck/docz/compare/v0.13.6...v0.13.7) (2018-12-26)
+
+**Note:** Version bump only for package docz-example-flow
+
+
+
+
+
 ## [0.13.6](https://github.com/pedronauck/docz/compare/v0.13.5...v0.13.6) (2018-12-26)
 
 **Note:** Version bump only for package docz-example-flow

--- a/examples/flow/package.json
+++ b/examples/flow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docz-example-flow",
-  "version": "0.13.6",
+  "version": "0.13.7",
   "license": "MIT",
   "scripts": {
     "dev": "docz dev",
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@babel/preset-flow": "^7.0.0",
     "babel-plugin-emotion": "^10.0.5",
-    "docz": "^0.13.6",
+    "docz": "^0.13.7",
     "flow-bin": "^0.89.0",
     "flow-typed": "^2.5.1"
   }

--- a/examples/react-native/CHANGELOG.md
+++ b/examples/react-native/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.13.7](https://github.com/pedronauck/docz/compare/v0.13.6...v0.13.7) (2018-12-26)
+
+**Note:** Version bump only for package docz-example-react-native
+
+
+
+
+
 ## [0.13.6](https://github.com/pedronauck/docz/compare/v0.13.5...v0.13.6) (2018-12-26)
 
 **Note:** Version bump only for package docz-example-react-native

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docz-example-react-native",
-  "version": "0.13.6",
+  "version": "0.13.7",
   "license": "MIT",
   "scripts": {
     "dev": "docz dev",
@@ -16,6 +16,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",
-    "docz": "^0.13.6"
+    "docz": "^0.13.7"
   }
 }

--- a/examples/styled-components/CHANGELOG.md
+++ b/examples/styled-components/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.13.7](https://github.com/pedronauck/docz/compare/v0.13.6...v0.13.7) (2018-12-26)
+
+**Note:** Version bump only for package docz-example-styled-components
+
+
+
+
+
 ## [0.13.6](https://github.com/pedronauck/docz/compare/v0.13.5...v0.13.6) (2018-12-26)
 
 **Note:** Version bump only for package docz-example-styled-components

--- a/examples/styled-components/package.json
+++ b/examples/styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docz-example-styled-components",
-  "version": "0.13.6",
+  "version": "0.13.7",
   "license": "MIT",
   "scripts": {
     "dev": "docz dev",
@@ -13,6 +13,6 @@
     "styled-components": "^4.1.3"
   },
   "devDependencies": {
-    "docz": "^0.13.6"
+    "docz": "^0.13.7"
   }
 }

--- a/examples/typescript/CHANGELOG.md
+++ b/examples/typescript/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.13.7](https://github.com/pedronauck/docz/compare/v0.13.6...v0.13.7) (2018-12-26)
+
+**Note:** Version bump only for package docz-example-typescript
+
+
+
+
+
 ## [0.13.6](https://github.com/pedronauck/docz/compare/v0.13.5...v0.13.6) (2018-12-26)
 
 **Note:** Version bump only for package docz-example-typescript

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docz-example-typescript",
-  "version": "0.13.6",
+  "version": "0.13.7",
   "license": "MIT",
   "scripts": {
     "dev": "docz dev",
@@ -9,8 +9,8 @@
   "dependencies": {
     "@emotion/core": "^10.0.5",
     "@emotion/styled": "^10.0.5",
-    "docz": "^0.13.6",
-    "docz-core": "^0.13.6",
+    "docz": "^0.13.7",
+    "docz-core": "^0.13.7",
     "react": "^16.7.0",
     "react-dom": "^16.7.0"
   },

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
   "packages": [
     "packages/**/*"
   ],
-  "version": "0.13.6",
+  "version": "0.13.7",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/docz-core/CHANGELOG.md
+++ b/packages/docz-core/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.13.7](https://github.com/pedronauck/docz/compare/v0.13.6...v0.13.7) (2018-12-26)
+
+**Note:** Version bump only for package docz-core
+
+
+
+
+
 ## [0.13.6](https://github.com/pedronauck/docz/compare/v0.13.5...v0.13.6) (2018-12-26)
 
 

--- a/packages/docz-core/package.json
+++ b/packages/docz-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docz-core",
-  "version": "0.13.6",
+  "version": "0.13.7",
   "description": "All docz core logic of bundle and parsing is included on this package",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/docz-core/src/commands/args.ts
+++ b/packages/docz-core/src/commands/args.ts
@@ -148,19 +148,19 @@ export const args = (env: Env) => (yargs: any) => {
   yargs.positional('typescript', {
     alias: 'ts',
     type: 'boolean',
-    default: getEnv('docz.typescript') || false,
+    default: getEnv('docz.typescript', false),
   })
   yargs.positional('propsParser', {
     type: 'boolean',
-    default: getEnv('docz.props.parser') || true,
+    default: getEnv('docz.props.parser', true),
   })
   yargs.positional('wrapper', {
     type: 'string',
-    default: getEnv('docz.wrapper') || null,
+    default: getEnv('docz.wrapper', null),
   })
   yargs.positional('indexHtml', {
     type: 'string',
-    default: getEnv('docz.index.html') || null,
+    default: getEnv('docz.index.html', null),
   })
   yargs.positional('ordering', {
     type: 'string',
@@ -168,7 +168,7 @@ export const args = (env: Env) => (yargs: any) => {
   })
   yargs.positional('debug', {
     type: 'boolean',
-    default: getEnv('docz.debug') || false,
+    default: getEnv('docz.debug', false),
   })
   yargs.positional('host', {
     type: 'string',
@@ -189,18 +189,18 @@ export const args = (env: Env) => (yargs: any) => {
   })
   yargs.positional('hahRouter', {
     type: 'boolean',
-    default: getEnv('docz.hash.router') || false,
+    default: getEnv('docz.hash.router', false),
   })
   yargs.positional('native', {
     type: 'boolean',
-    default: getEnv('docz.native') || false,
+    default: getEnv('docz.native', false),
   })
   yargs.positional('codeSandbox', {
     type: 'boolean',
-    default: getEnv('docz.codeSandbox') || true,
+    default: getEnv('docz.codeSandbox', true),
   })
   yargs.positional('sourcemaps', {
     type: 'boolean',
-    default: getEnv('docz.sourcemaps') || true,
+    default: getEnv('docz.sourcemaps', true),
   })
 }

--- a/packages/docz-core/src/webpack/devserver.ts
+++ b/packages/docz-core/src/webpack/devserver.ts
@@ -11,7 +11,6 @@ import { ServerHooks } from '../Bundler'
 export const devServerConfig = (hooks: ServerHooks, args: Args) => {
   const srcPath = path.resolve(paths.root, args.src)
   const publicDirPath = path.resolve(paths.root, args.public)
-  const publicDir = path.join(paths.root, publicDirPath)
   const nonExistentDir = path.resolve(__dirname, 'non-existent')
 
   return {
@@ -36,7 +35,7 @@ export const devServerConfig = (hooks: ServerHooks, args: Args) => {
     before(app: any, server: any): void {
       app.use(evalSourceMapMiddleware(server))
       app.use(errorOverlayMiddleware())
-      app.use('/public', express.static(publicDir))
+      app.use('/public', express.static(publicDirPath))
       hooks.onPreCreateApp<any>(app)
     },
     after(app: any): void {

--- a/packages/docz-theme-default/CHANGELOG.md
+++ b/packages/docz-theme-default/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.13.7](https://github.com/pedronauck/docz/compare/v0.13.6...v0.13.7) (2018-12-26)
+
+**Note:** Version bump only for package docz-theme-default
+
+
+
+
+
 ## [0.13.6](https://github.com/pedronauck/docz/compare/v0.13.5...v0.13.6) (2018-12-26)
 
 **Note:** Version bump only for package docz-theme-default

--- a/packages/docz-theme-default/package.json
+++ b/packages/docz-theme-default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docz-theme-default",
-  "version": "0.13.6",
+  "version": "0.13.7",
   "description": "The default theme of docz",
   "license": "MIT",
   "main": "dist/index.js",
@@ -25,7 +25,7 @@
     "@emotion/styled": "^10.0.5",
     "codemirror": "^5.42.2",
     "copy-text-to-clipboard": "^1.0.4",
-    "docz": "^0.13.6",
+    "docz": "^0.13.7",
     "emotion-theming": "^10.0.5",
     "facepaint": "^1.2.1",
     "hotkeys-js": "^3.4.1",

--- a/packages/docz/CHANGELOG.md
+++ b/packages/docz/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.13.7](https://github.com/pedronauck/docz/compare/v0.13.6...v0.13.7) (2018-12-26)
+
+**Note:** Version bump only for package docz
+
+
+
+
+
 ## [0.13.6](https://github.com/pedronauck/docz/compare/v0.13.5...v0.13.6) (2018-12-26)
 
 **Note:** Version bump only for package docz

--- a/packages/docz/package.json
+++ b/packages/docz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docz",
-  "version": "0.13.6",
+  "version": "0.13.7",
   "description": "It's has never been so easy to documents your things!",
   "license": "MIT",
   "main": "dist/index.js",
@@ -33,7 +33,7 @@
     "callbag-subject": "^1.0.2",
     "capitalize": "^2.0.0",
     "deepmerge": "^3.0.0",
-    "docz-core": "^0.13.6",
+    "docz-core": "^0.13.7",
     "fast-deep-equal": "^2.0.1",
     "lodash": "^4.17.11",
     "prop-types": "^15.6.2",


### PR DESCRIPTION
### Description

Using `{ public: './public' }` in `doczrc.js` led to Express serving the wrong static path (at least on windows). This PR fixes that.

Tested on Windows 10 and on Ubuntu (on Windows Linux Subsystem) to test both win and posix file separators.

Tested with both relative paths and absolute paths on both OS.