### PR TITLE
fix(docz-theme-default): fix duplicates in search (#532)

### DIFF
--- a/packages/docz-theme-default/src/components/shared/Sidebar/index.tsx
+++ b/packages/docz-theme-default/src/components/shared/Sidebar/index.tsx
@@ -224,8 +224,9 @@ class SidebarBase extends Component<SidebarProps, SidebarState> {
   private match = (val: string, menu: MenuItem[]) => {
     const items = menu.map(item => [item].concat(item.menu || []))
     const flattened = flattendepth(items, 2)
+    const flattenedDeduplicated = [...(new Set(flattened))]
 
-    return match(flattened, val, { keys: ['name'] })
+    return match(flattenedDeduplicated, val, { keys: ['name'] })
   }
 
   private search = (initial: MenuItem[], menus: MenuItem[], val: string) => {


### PR DESCRIPTION
## Bug

Bug described in [Issue #532](https://github.com/pedronauck/docz/issues/532)

## Solution

Deduplicate menu items before match and display.