### PR TITLE
fix(gatsby-theme-docz): use options from gatsby-config

### DIFF
--- a/core/gatsby-theme-docz/src/node/onPreInit.js
+++ b/core/gatsby-theme-docz/src/node/onPreInit.js
@@ -17,7 +17,7 @@ const touchTemplateWithPaths = paths => async (filepath, opts) => {
   await touch(dest, raw)
 }
 
-module.exports = async opts => {
+module.exports = async (_, opts) => {
   const { paths, ...config } = await parseConfig(opts)
   const componentPath = mountComponentPath(paths)
   const touchTemplate = touchTemplateWithPaths(paths)


### PR DESCRIPTION
**NOTE:** This is a PR against the v1 branch

### Description

The gatsby-node `onPreInit` hook passes in two arguments, the _second_ of which is the plugin options.

This fixes merging of options defined for gatsby-theme-docz in a project's `gatsby-config.js`.