### PR TITLE
fix(docz-theme-default): toggle active links on location change

### DIFF
--- a/core/docz-theme-default/src/components/shared/Sidebar/SmallLink.tsx
+++ b/core/docz-theme-default/src/components/shared/Sidebar/SmallLink.tsx
@@ -66,7 +66,7 @@ export const SmallLink: SFC<SmallLinkProps> = ({
   useEffect(() => {
     const currentHash = location.hash && location.hash.slice(1, Infinity)
     setActive(Boolean(slug === currentHash))
-  }, [])
+  }, [location])
 
   return <Link as={Component} {...props} className={isActive ? 'active' : ''} />
 }


### PR DESCRIPTION
**NOTE:** This PR is against the v1 branch

### Description

This fixes the Sidebar `SmallLink` active state not updating when router `location` changes.