### PR TITLE
fix(docz): add window check to useWindowSize hook

### DIFF
--- a/core/docz/src/hooks/useWindowSize.ts
+++ b/core/docz/src/hooks/useWindowSize.ts
@@ -1,16 +1,26 @@
 import { useState, useEffect } from 'react'
 import { throttle } from 'lodash/fp'
 
-const getSize = () => ({
-  innerHeight: window.innerHeight,
-  innerWidth: window.innerWidth,
-  outerHeight: window.outerHeight,
-  outerWidth: window.outerWidth,
+const isClient = typeof window === 'object'
+
+const getSize = (initialWidth: number, initialHeight: number) => ({
+  innerHeight: isClient ? window.innerHeight : initialHeight,
+  innerWidth: isClient ? window.innerWidth : initialWidth,
+  outerHeight: isClient ? window.outerHeight : initialHeight,
+  outerWidth: isClient ? window.outerWidth : initialWidth,
 })
 
-export const useWindowSize = () => {
-  const [windowSize, setWindowSize] = useState(getSize())
-  const tSetWindowResize = throttle(300, () => setWindowSize(getSize()))
+export const useWindowSize = (
+  throttleMs: number = 300,
+  initialWidth = Infinity,
+  initialHeight = Infinity
+) => {
+  const [windowSize, setWindowSize] = useState(
+    getSize(initialHeight, initialHeight)
+  )
+  const tSetWindowResize = throttle(throttleMs, () =>
+    setWindowSize(getSize(initialHeight, initialHeight))
+  )
 
   useEffect(() => {
     window.addEventListener('resize', tSetWindowResize)


### PR DESCRIPTION
### Description

The pr is against v1 branch.

It does the following:
1. Adds a window check for the case when using on a project with ssr;
2. Adds a throttleMs argument to pass to the main function(with default left from the original implementation).

The pr is implemented to fix the specific issue with the build step in gatsby, but also remediate any ssr compilation issues due to window object being undefined.  