### PR TITLE
fix(docz-core): initialize config state on data server start

### DIFF
--- a/core/docz-core/src/states/config.ts
+++ b/core/docz-core/src/states/config.ts
@@ -56,7 +56,7 @@ export const state = (config: Config): State => {
     id: 'config',
     start: async params => {
       const fn = async () => update(params, initial)
-
+      await update(params, initial)
       watcher.on('add', fn)
       watcher.on('change', fn)
       watcher.on('unlink', fn)


### PR DESCRIPTION
**NOTE:** This is a PR against the v1 branch

### Description

In a project without docz config files (`.doczrc`, `docz.config.js`, etc), for example, in a gatsby app using gatsby-theme-docz with config only in `gatsby-config.js`, the config state is not initialized, which causes errors when the config state is read.