### PR TITLE
fix(docz-theme-default): Support absolute page elements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ The are just two directories to care about if you would like to contribute:
 
 There are lots of [packages](https://github.com/pedronauck/docz/tree/master/packages) that are necessary to run docz, the most important packages that are important to care about:
 
-#### **[docz-core](https://github.com/pedronauck/docz/tree/master/packages/docz)**
+#### **[docz-core](https://github.com/pedronauck/docz/tree/master/packages/docz-core)**
 - This is the core of docz. All build algorithms, server process and parses belongs to here.
 - If you break this package, probably you'll break all packages! Please, be carefull.
 - All cli commands are built here and imported on `docz` package using `./bin` script.

--- a/README.md
+++ b/README.md
@@ -112,6 +112,18 @@ Simplicity is one of our core principles. Therefore, getting started with **docz
 $ yarn add docz docz-theme-default --dev
 ```
 
+> Special note for `create-react-app` and other users
+
+> There is a known temporary version mismatch issue in v0.13 of `docz` that causes an `Uncaught TypeError: Cannot read property 'close' of undefined` error. To fix, add this to your `package.json` and rerun `rm yarn.lock && yarn`:
+
+```json
+"resolutions": {
+  "ansi-styles": "^3.2.0"
+}
+```
+
+> See associated tracking issues for [`webpack v4.28.4`](https://github.com/pedronauck/docz/issues/596) and [`ansi-styles v3.2.0`](https://github.com/pedronauck/docz/issues/536). You can [track v0.14 development here](https://github.com/pedronauck/docz/tree/v0.14).
+
 Then create some `.mdx` anywhere inside your project:
 
 ```markdown

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ This project exists thanks to all the people who contribute. [[Contribute](CONTR
 
 ## 💭 &nbsp; Needing Help?
 
-If you need some help you can chat with us on [our Discord server](https://discord.gg/Qec87en), you have a great team to help you:
+If you need some help you can chat with us on [our Discord server](https://discord.gg/Qec87en), we have a great team to help you:
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore -->

--- a/README.md
+++ b/README.md
@@ -29,14 +29,6 @@
   </a>
 </p>
 
-## 🙌🏻 &nbsp; Sponsors
-
-Thanks for all people that support us 🙏🏻
-
-<a href="https://impulso.work" target="_blank">
-  <img src="https://cdn-std.dprcdn.net/files/acc_649651/OosgCe" width="60">
-</a>
-
 ## 🎩 &nbsp; Features
 
 - 🧘 **Zero config and easy.** Don't worry about complex configurations steps.

--- a/packages/docz-theme-default/src/components/ui/Page.tsx
+++ b/packages/docz-theme-default/src/components/ui/Page.tsx
@@ -16,6 +16,7 @@ const Wrapper = styled('div')`
   background: ${get('colors.background')};
   font-size: 18px;
   min-width: 0;
+  position: relative;
 `
 
 export const Container = styled('div')`


### PR DESCRIPTION
### Description

Absolute page elements should not cover the sidebar
### Screenshots

| Before | After |
| ------ | ----- |
|![Screen Shot 2019-03-14 at 12 50 06](https://user-images.githubusercontent.com/27810942/54354858-ed5e7380-4657-11e9-9f35-7158e6afd930.png)|![Screen Shot 2019-03-14 at 12 50 54](https://user-images.githubusercontent.com/27810942/54354870-f7807200-4657-11e9-82c4-09e1b26ee533.png)|