### PR TITLE
[v1 migration guide] Grammar and vocabulary improvements

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -8,7 +8,7 @@ We made a [huge improvement](https://github.com/pedronauck/docz/commit/f57f987df
 
 ## Spectrum instead of Discord
 
-Another thing that we changed, it's now we're attending on Spectrum instead of Discord. You can check the [Docz community](https://spectrum.chat/docz) and ask us whatever you want!
+Another thing that has changed is our community is now on Spectrum instead of Discord. You can check the [Docz community](https://spectrum.chat/docz) and ask us whatever you want!
 
 ## No more render props
 

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1,6 +1,6 @@
 # Migration Guide
 
-The [v1 release](https://github.com/pedronauck/docz/pull/656) was one of our big releases so far and a lot of breaking changes was introduced. So, there's a few apis that changed and you need to update your code if you're coming from previous versions. It's not a big deal, but you need to follow this guide in order to get Docz running properly on your project after an upgrade.
+The [v1 release](https://github.com/pedronauck/docz/pull/656) was one of our big releases so far and a lot of breaking changes were introduced. A few APIs were changed and you will need to update your code if you're coming from a previous version. It's not a big deal, but you need to follow this guide in order to get Docz running properly on your project after the upgrade.
 
 ## Update React to use Hooks
 

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -86,7 +86,7 @@ import MyComponent from './my-components'
 
 ## Remove hash router support
 
-In the newest version of docz, because of some performance and bundle issues, we are now using `@reach/router` instead of `react-router`. As `@reach/router` doesn't have an official support for hash routing yet, and as there are lots of good free services to host static sites besides Github pages ([Surge](https://surge.sh/), for instance, is free and has full support for browser history navigation) we decided to deprecate the hash router support.
+In the newest version of Docz, because of some performance and bundle issues, we are now using `@reach/router` instead of `react-router`. As `@reach/router` doesn't have official support for hash routing yet, and as there are lots of good free services to host static sites besides Github pages ([Surge](https://surge.sh/), for instance, is free and has full support for browser history navigation) we have decided to deprecate hash router support.
 
 ## Creating and using Docz themes
 

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1,6 +1,6 @@
 # Migration Guide
 
-The [v1 release](https://github.com/pedronauck/docz/pull/656) was one of our big releases and a lot of breaking changes was introduced. So, there's few apis that changed and you need to update your code if you're coming from previous versions. It's not a big deal, but you need to follow this guide in order to get Docz running properly on your project.
+The [v1 release](https://github.com/pedronauck/docz/pull/656) was one of our big releases so far and a lot of breaking changes was introduced. So, there's a few apis that changed and you need to update your code if you're coming from previous versions. It's not a big deal, but you need to follow this guide in order to get Docz running properly on your project after an upgrade.
 
 ## Update React to use Hooks
 
@@ -8,11 +8,11 @@ We made a [huge improvement](https://github.com/pedronauck/docz/commit/f57f987df
 
 ## Spectrum instead of Discord
 
-Another thing that we changed, it's now we're attending on Spectrum instead of Discord. You can check the [Docz community](https://spectrum.chat/docz) and ask we whatever you want!
+Another thing that we changed, it's now we're attending on Spectrum instead of Discord. You can check the [Docz community](https://spectrum.chat/docz) and ask us whatever you want!
 
 ## No more render props
 
-In the oldest version of docz, we're using render props as data components in order to get data from the docz database and use it on themes. Now, all this render props became a hook. This is a huge improvement, since it's so easier to use them.
+In the older version of docz, we're using render props as data components in order to get data from the docz database and use it on themes. Now, all this render props became hooks. This is a huge improvement, since it's much easier to use them.
 
 #### `<Docs>` now is `useDocs()`
 
@@ -60,7 +60,7 @@ const components = useComponents()
 
 ## Order deprecated removed
 
-Since [v0.12.4](https://github.com/pedronauck/docz/releases/tag/v0.12.4) we launched `menu` property to create and sort your menu, and the `ordering` frontmatter field was deprecated. So, now we're removing this property. If you wanna see more information about the `menu` order property, you can take a look at the `Ordering` session on our website.
+Since [v0.12.4](https://github.com/pedronauck/docz/releases/tag/v0.12.4) we launched `menu` property to create and sort the menu, and the `ordering` frontmatter field was deprecated. So, now we're removing this property. If you wanna see more information about the `menu` order property, you can take a look at the `Ordering` session on our website.
 
 ## Use Props instead of PropsTable
 
@@ -86,14 +86,14 @@ import MyComponent from './my-components'
 
 ## Remove hash router support
 
-In the newest version of docz, because of some performance and bundle issues, now we are using `@reach/router` instead of `react-router`. So, how `@reach/router` doesn't have a official support for hash router yet and you have a lot of good free services to host your site instead of use Github pages - and get all benefits of browser history, of course - we decided to deprecated the hash router support.
+In the newest version of docz, because of some performance and bundle issues, we are now using `@reach/router` instead of `react-router`. As `@reach/router` doesn't have an official support for hash routing yet, and as there are lots of good free services to host static sites besides Github pages ([Surge](https://surge.sh/), for instance, is free and has full support for browser history navigation) we decided to deprecate the hash router support.
 
 ## Creating and using Docz themes
 
-The process to create themes for docz it's very similar, there's not a big changes here, but you need to know about few changes that we made.
+The process to create themes for docz is very similar to the previous one; there are no big changes here, but you need to know a few changes that we made.
 
-- The first one, is you don't have `DocPreview` anymore, instead of that, was introduced `ComponentsProvider` component.
-- The second one, is the `render` field passed in the components mapper now is `playground`.
+- The first one, is you don't have `DocPreview` anymore. Instead, we introduced the `ComponentsProvider` component.
+- The second one, is that the `render` field previously passed in the components mapper now is called `playground`.
 - And the last one, is now you need to pass a children for your theme.
 
 #### The old way

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -93,7 +93,7 @@ In the newest version of Docz, because of some performance and bundle issues, we
 The process to create themes for docz is very similar to the previous one; there are no big changes here, but you need to know a few changes that we made.
 
 - The first one, is you don't have `DocPreview` anymore. Instead, we introduced the `ComponentsProvider` component.
-- The second one, is that the `render` field previously passed in the components mapper now is called `playground`.
+- The second one is that the `render` field previously passed in the components mapper; now it is called `playground`.
 - And the last one, is now you need to pass a children for your theme.
 
 #### The old way


### PR DESCRIPTION
### Description

Some minor grammar and vocabulary fixes or improvements on the migration guide.

**Edit**
I'm no english native nor expert, and though I don't mind minor grammar mistakes, there are some of the ones I fixed which actually change the meaning of the phrases - which can lead to misunderstanding, most probably to the native speakers (non-native english-speaking people usually read english texts taking account for possible foreignism and non-literal translations).