### PR TITLE
chore: fix typo, Hamburguer to Hamburger

### DIFF
--- a/core/docz-theme-default/src/components/shared/Sidebar/Hamburger.tsx
+++ b/core/docz-theme-default/src/components/shared/Sidebar/Hamburger.tsx
@@ -96,11 +96,11 @@ const ToggleButton = styled.button<OpenProps>`
   })};
 `
 
-interface HamburguerProps extends OpenProps {
+interface HamburgerProps extends OpenProps {
   onClick: (ev: React.SyntheticEvent<any>) => void
 }
 
-export const Hamburguer: SFC<HamburguerProps> = ({ opened, onClick }) => (
+export const Hamburger: SFC<HamburgerProps> = ({ opened, onClick }) => (
   <ToggleButton opened={opened} onClick={onClick}>
     <Icon opened={opened}>
       <IconLine opened={opened} />

--- a/core/docz-theme-default/src/components/shared/Sidebar/index.tsx
+++ b/core/docz-theme-default/src/components/shared/Sidebar/index.tsx
@@ -7,7 +7,7 @@ import { Logo } from '../Logo'
 import { Search } from '../Search'
 import { Menu } from './Menu'
 import { Docz } from './Docz'
-import { Hamburguer } from './Hamburguer'
+import { Hamburger } from './Hamburger'
 
 import { get } from '@utils/theme'
 import { mq, breakpoints } from '@styles/responsive'
@@ -147,7 +147,7 @@ export const Sidebar: SFC = () => {
     <Fragment>
       <Wrapper opened={hidden}>
         <Content>
-          <Hamburguer opened={!hidden} onClick={handleSidebarToggle} />
+          <Hamburger opened={!hidden} onClick={handleSidebarToggle} />
           <Logo showBg={!hidden} />
           <Search onSearch={setQuery} />
 


### PR DESCRIPTION
### Description

Whilst taking a look through the codebase I noticed the `Hamburger` component contained a typo.
