### PR TITLE
fix: allows hamburger menu to be opened on mobile

### DIFF
--- a/core/docz-theme-default/src/components/shared/Sidebar/index.tsx
+++ b/core/docz-theme-default/src/components/shared/Sidebar/index.tsx
@@ -138,7 +138,6 @@ export const Sidebar: SFC = () => {
   }
 
   const handleSidebarToggle = () => {
-    if (isDesktop) return
     setHidden(s => !s)
     addOverlayClass(!hidden)
   }


### PR DESCRIPTION
### Description

Fixes: #693

Allows the hamburger menu to be opened when viewing the site at mobile size on a desktop browser.