### PR TITLE
Resolve symlinks right for the react-docgen

### DIFF
--- a/core/docz-core/src/utils/docgen.ts
+++ b/core/docz-core/src/utils/docgen.ts
@@ -13,7 +13,7 @@ import ts from 'typescript'
 import * as paths from '../config/paths'
 import { Config } from '../config/argv'
 
-const fileFullPath = (filepath: string) => path.join(paths.root, filepath)
+const fileFullPath = (filepath: string) => require.resolve(path.join(paths.root, filepath))
 
 const throwError = (err: any) => {
   logger.fatal(`Error parsing static types`)


### PR DESCRIPTION
### Description

It's important to use react-docgen the real filepath for the symlinks, because otherwise it will not match by `__filemeta .filename` in `Props` (https://github.com/pedronauck/docz/blob/master/core/docz/src/components/Props.tsx#L98)