### PR TITLE
fix: mobile menu following anchor clicks

### DIFF
--- a/core/docz-theme-default/src/components/shared/Sidebar/index.tsx
+++ b/core/docz-theme-default/src/components/shared/Sidebar/index.tsx
@@ -45,6 +45,7 @@ const Wrapper = styled.div<WrapperProps>`
 
   @media screen and (max-width: ${breakpoints.desktop - 1}px) {
     transform: translateX(${p => (p.opened ? '-100%' : '0')});
+    position: ${p => (p.opened ? 'auto' : 'fixed')};
   }
 
   ${get('styles.sidebar')};


### PR DESCRIPTION
### Description

Resolves: #495 

whenever a user clicked an anchor link with the mobile menu open it
would cause the mobile menu to re-position itself to half-way off the
page


### Review

- [ ] Open mobile menu and click on an anchor link

### Screenshots

| Before | After |
| ------ | ----- |
| ![](https://user-images.githubusercontent.com/16697651/49687711-ff96b600-fb2c-11e8-994d-3fde79f58006.png) | ![Screenshot 2019-03-24 at 15 31 08](https://user-images.githubusercontent.com/8593744/54881645-e4d11e80-4e49-11e9-9522-1cd62264cfaf.png) |