### PR TITLE
chore(docz-theme-default): export enhance from docz-theme-default

### DIFF
--- a/core/docz-theme-default/src/index.tsx
+++ b/core/docz-theme-default/src/index.tsx
@@ -16,7 +16,7 @@ const Theme: SFC = ({ children }) => (
   </ThemeProvider>
 )
 
-const enhance = theme(config, ({ mode, codemirrorTheme, ...config }) => ({
+export const enhance = theme(config, ({ mode, codemirrorTheme, ...config }) => ({
   ...config,
   mode,
   codemirrorTheme: codemirrorTheme || `docz-${mode}`,


### PR DESCRIPTION
### Description

In continuation of the discussion here #615 (comment) it would be great to have an ability to import default enhancer, that already configured for the docz components.

At this moment it's quite hard to use imported docz components, because they work with a specific context, that you should build by your side.
