### PR TITLE
(fix) Search icon and sidebar top border.

### DIFF
--- a/core/docz-theme-default/src/components/shared/Logo/index.tsx
+++ b/core/docz-theme-default/src/components/shared/Logo/index.tsx
@@ -43,6 +43,8 @@ const Wrapper = styled.div<WrapperProps>`
       height: ${p => (p.showBg ? '3px' : 0)};
     }
   }
+
+  ${get('styles.logo')};
 `
 
 const LogoImg = styled('img')`

--- a/core/docz-theme-default/src/components/shared/Search/index.tsx
+++ b/core/docz-theme-default/src/components/shared/Search/index.tsx
@@ -20,7 +20,7 @@ const Wrapper = styled.div`
 
 const Icon = styled(SearchIcon)`
   stroke: ${sidebarText};
-  width: 20px;
+  min-width: 20px;
   opacity: 0.5;
 `
 


### PR DESCRIPTION
### Description

This should fix the sidebar search icon being tiny. It will allow to customize the sidebar logo component, e.g. to hide the top border line.

### Review

- [ ] Check if sidebar search icon is norma size.

### Screenshots

| Before | After |
| ------ | ----- |
| <img width="280" alt="Screenshot 2019-03-26 at 00 10 45" src="https://user-images.githubusercontent.com/496255/54960098-a2980200-4f5b-11e9-9d89-9f238f4febc4.png">  | <img width="282" alt="Screenshot 2019-03-26 at 00 11 32" src="https://user-images.githubusercontent.com/496255/54960127-bb081c80-4f5b-11e9-8a33-ce82fefe03b9.png"> |
| <img width="281" alt="Screenshot 2019-03-26 at 00 12 31" src="https://user-images.githubusercontent.com/496255/54960185-e2f78000-4f5b-11e9-8128-2bc5d362385e.png"> | <img width="282" alt="Screenshot 2019-03-26 at 00 13 22" src="https://user-images.githubusercontent.com/496255/54960207-fc003100-4f5b-11e9-8e40-4ac217afd58b.png"> |




