### PR TITLE
fix(docz-theme-default): apply ignore in props parsing

### DIFF
--- a/core/docz-core/src/states/props.ts
+++ b/core/docz-core/src/states/props.ts
@@ -9,12 +9,12 @@ import { Config } from '../config/argv'
 import { docgen } from '../utils/docgen'
 
 const getPattern = (config: Config) => {
-  const { typescript } = config
+  const { typescript, ignore } = config
   return [
     typescript ? '**/*.{ts,tsx}' : '**/*.{js,jsx,mjs}',
     '!**/node_modules',
     '!**/doczrc.js',
-  ]
+  ].concat(ignore.map(entry => `!**/${entry}`))
 }
 
 export const mapToArray = (map: any = []) =>


### PR DESCRIPTION
### Description

Apply ignore configuration in props parsing.
If not applied, if there is a folder with a lot of files, the parsing take a long long time to finish.

I don't know how to explain more about it, feel free to ask for more details.

