### PR TITLE
fix(docz-core): menu (entries) not initialized on build

### DIFF
--- a/core/docz-core/src/states/entries.ts
+++ b/core/docz-core/src/states/entries.ts
@@ -38,6 +38,7 @@ export const state = (entries: Entries, config: Config): State => {
     start: async params => {
       const update = updateEntries(entries)
 
+      update(params);
       watcher.on('add', async () => update(params))
       watcher.on('change', async () => update(params))
       watcher.on('unlink', async () => update(params))


### PR DESCRIPTION
### Description

It's hard to reproduce in docz examples, but in my documentation on the build script menu wasn't initialized on the left side panel.

After debugging, I noticed what chokidar don't call events on start and already collected all MDX files and entities didn't initialize