### PR TITLE
Fix links with base

### DIFF
--- a/core/docz-theme-default/src/components/ui/H2.tsx
+++ b/core/docz-theme-default/src/components/ui/H2.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import { SFC } from 'react'
-import { useConfig } from 'docz'
 import styled from 'styled-components'
 import Hash from 'react-feather/dist/icons/hash'
 
@@ -28,13 +27,11 @@ const Heading = styled.h2`
 
 export const H2: SFC<React.HTMLAttributes<any>> = ({ children, ...props }) => {
   const pathname = typeof window !== 'undefined' ? location.pathname : '/'
-  const { linkComponent: Link } = useConfig()
-  if (!Link) return null
   return (
     <Heading {...props}>
-      <Link aria-hidden to={`${pathname}#${props.id}`}>
+      <a aria-hidden href={`${pathname}#${props.id}`}>
         <Icon className="heading--Icon" height={20} />
-      </Link>
+      </a>
       {children}
     </Heading>
   )

--- a/core/docz/src/components/Link.tsx
+++ b/core/docz/src/components/Link.tsx
@@ -2,6 +2,8 @@ import * as React from 'react'
 import { useCallback } from 'react'
 import { Link as BaseLink, LinkProps, LinkGetProps } from '@reach/router'
 
+declare var DOCZ_BASE_URL: string
+
 export { LinkProps }
 export const Link = React.forwardRef<any, LinkProps<any>>((props, ref) => {
   const isActive = useCallback(
@@ -11,7 +13,11 @@ export const Link = React.forwardRef<any, LinkProps<any>>((props, ref) => {
     [props.className]
   )
 
-  return <BaseLink {...props} getProps={isActive} ref={ref} />
+  const base = DOCZ_BASE_URL.slice(0, -1)
+  const { to } = props
+  const link = `${base}${to}`
+
+  return <BaseLink {...props} to={link} getProps={isActive} ref={ref} />
 })
 
 Link.displayName = 'Link'


### PR DESCRIPTION
### Description

Opened to fix #722 

`docz build --base /base/path` not working properly in in 1.0.0-rc.3
The navigation links do not use `/base/path` as supposed.

