### PR TITLE
feat(docz): add Description component

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,12 @@ Next, add some `.mdx` files anywhere inside your project:
 name: Button
 ---
 
-import { Playground, Props } from 'docz'
+import { Description, Playground, Props } from 'docz'
 import Button from './'
 
 # Button
+
+<Description of={Button} />
 
 <Props of={Button} />
 

--- a/core/docz/src/components/Description.tsx
+++ b/core/docz/src/components/Description.tsx
@@ -1,0 +1,30 @@
+import { get, last } from "lodash/fp";
+import * as React from 'react';
+import { ComponentClass, createElement, FunctionComponent, SFC } from 'react';
+import { doczState } from '../state';
+import { ComponentWithDocGenInfo } from "./Props";
+
+type Tag = FunctionComponent | ComponentClass | string;
+
+export interface DescriptionProps  {
+  of: ComponentWithDocGenInfo;
+  as?: Tag;
+}
+
+export const Description: SFC<DescriptionProps> = ({ of: component, as: tag }) => {
+  const { props: stateProps } = React.useContext(doczState.context);
+  const filename = get("__filemeta.filename", component);
+  const found =
+    stateProps &&
+    stateProps.length > 0 &&
+    stateProps.find(item => item.key === filename);
+
+  const definition = last(found ? found.value : []);
+  const description = get("description", definition) || "";
+
+  if (!description) {
+    return null;
+  }
+  
+  return createElement(tag || "span", null, [description]);
+};

--- a/core/docz/src/index.ts
+++ b/core/docz/src/index.ts
@@ -1,5 +1,6 @@
 export { Playground } from './components/AsyncPlayground'
 export { AsyncRoute, loadRoute } from './components/AsyncRoute'
+export { Description } from './components/Description'
 export { Link, LinkProps } from './components/Link'
 export { Props, PropsComponentProps } from './components/Props'
 export { Routes } from './components/Routes'

--- a/examples/basic/src/components/Button.jsx
+++ b/examples/basic/src/components/Button.jsx
@@ -58,6 +58,10 @@ const ButtonStyled = styled('button')`
   border-radius: 3px;
 `
 
+/** 
+ * Buttons make common actions more obvious and help users more easily perform them. 
+ * Buttons use labels and sometimes icons to communicate the action that will occur when the user touches them.
+ */
 export const Button = ({ children, ...props }) => (
   <ButtonStyled {...props}>{children}</ButtonStyled>
 )

--- a/examples/basic/src/components/Button.mdx
+++ b/examples/basic/src/components/Button.mdx
@@ -3,12 +3,12 @@ name: Button
 menu: Components
 ---
 
-import { Playground, Props } from 'docz'
+import { Description, Playground, Props } from 'docz'
 import { Button } from './Button'
 
 # Button
 
-Buttons make common actions more obvious and help users more easily perform them. Buttons use labels and sometimes icons to communicate the action that will occur when the user touches them.
+<Description of={Button} />
 
 ### Best practices
 


### PR DESCRIPTION
### Description

Adds the `<Description>` component to print component descriptions, as per #736 

### Example

*MyComponent.tsx*
```jsx
import React from "react";

/**
 * The greatest component in the world
 */
export const MyComponent = () => <div />;

export default MyComponent;
```

*MyComponent.mdx*
```
import { Description } from "docz";
import MyComponent from "./MyComponent";

# My Component

<Description of={MyComponent} />
```

### Screenshots

| Before | After |
| ------ | ----- |
|  ![image](https://user-images.githubusercontent.com/255015/55263842-c6ec2b00-5248-11e9-9c87-043776ce3e50.png) | ![image](https://user-images.githubusercontent.com/255015/55263828-b50a8800-5248-11e9-88d4-022c603a3296.png) |