### PR TITLE
Add config setting to customise chokidar watch ignored paths regex

### DIFF
--- a/core/docz-core/src/config/argv.ts
+++ b/core/docz-core/src/config/argv.ts
@@ -57,6 +57,7 @@ export interface Argv {
   src: string
   files: string | string[]
   ignore: string[]
+  watchIgnore: string
   public: string
   dest: string
   editBranch: string

--- a/core/docz-core/src/states/config.ts
+++ b/core/docz-core/src/states/config.ts
@@ -49,9 +49,11 @@ const update = async (params: Params, initial: Payload, { config }: Config) => {
 export const state = (config: Config): State => {
   const initial = getInitialConfig(config)
   const glob = config.config || finds('docz')
+  const ignored = config.watchIgnore || /(((^|[\/\\])\..+)|(node_modules))/
+
   const watcher = chokidar.watch(glob, {
     cwd: paths.root,
-    ignored: /(((^|[\/\\])\..+)|(node_modules))/,
+    ignored,
     persistent: true,
   })
 

--- a/core/docz-core/src/states/entries.ts
+++ b/core/docz-core/src/states/entries.ts
@@ -24,10 +24,11 @@ export const state = (entries: Entries, config: Config): State => {
   const files = Array.isArray(config.files)
     ? config.files.map(filePath => path.join(src, filePath))
     : path.join(src, config.files)
+  const ignored = config.watchIgnore || /(((^|[\/\\])\..+)|(node_modules))/
 
   const watcher = chokidar.watch(files, {
     cwd: paths.root,
-    ignored: /(((^|[\/\\])\..+)|(node_modules))/,
+    ignored,
     persistent: true,
   })
 

--- a/core/docz-core/src/states/props.ts
+++ b/core/docz-core/src/states/props.ts
@@ -47,9 +47,11 @@ const remove = (p: Params) => async (filepath: string) => {
 
 export const state = (config: Config): State => {
   const pattern = getPattern(config)
+  const ignored = config.watchIgnore || /(((^|[\/\\])\..+)|(node_modules))/
+
   const watcher = chokidar.watch(pattern, {
     cwd: paths.root,
-    ignored: /(((^|[\/\\])\..+)|(node_modules))/,
+    ignored,
     persistent: true,
   })
 


### PR DESCRIPTION
### Description

Fixes/implements #740 by allowing customisation of chokidar watch's `ignored` setting by providing a corresponding `watchIgnore` setting in docz config.