### PR TITLE
feat(docz-theme-default): add Editor to component exports

### DIFF
--- a/core/docz-theme-default/src/components/ui/index.ts
+++ b/core/docz-theme-default/src/components/ui/index.ts
@@ -1,5 +1,6 @@
 import { Playground } from './Playground'
 import { Blockquote } from './Blockquote'
+import { Editor } from './Editor'
 import { H1 } from './H1'
 import { H2 } from './H2'
 import { H3 } from './H3'
@@ -22,6 +23,7 @@ import { UnorderedList } from './UnorderedList'
 export const components = {
   a: Link,
   blockquote: Blockquote,
+  editor: Editor,
   h1: H1,
   h2: H2,
   h3: H3,


### PR DESCRIPTION
### Description
Adds `Editor` component to existing component exports in default theme

Addresses #749 