### PR TITLE
fix(docz-core): default ignore paths

### DIFF
--- a/core/docz-core/src/config/docz.ts
+++ b/core/docz-core/src/config/docz.ts
@@ -30,11 +30,11 @@ export const doczRcBaseConfig = {
   mdPlugins: [],
   hastPlugins: [],
   ignore: [
-    'readme.md',
-    'changelog.md',
-    'code_of_conduct.md',
-    'contributing.md',
-    'license.md',
+    '**/readme.md',
+    '**/changelog.md',
+    '**/code_of_conduct.md',
+    '**/contributing.md',
+    '**/license.md',
   ],
 }
 


### PR DESCRIPTION
Fixes #753 

Ignore paths seem not to support `matchBase`.

[This PR](https://github.com/jedmao/queso/pull/16) and its [Netlify build](https://deploy-preview-16--quesojs.netlify.com/) is how I know this fix works.