### PR TITLE
fix(gatsby-theme-docz): don't add base to page path

### DIFF
--- a/core/gatsby-theme-docz/src/node/createPages.js
+++ b/core/gatsby-theme-docz/src/node/createPages.js
@@ -2,10 +2,6 @@ const path = require('path')
 const { getDoczConfig } = require('../utils/parseConfig')
 const { get } = require('lodash/fp')
 
-const mountRoute = (base = '/', route) => {
-  return `${base === '/' ? '' : base}${route}`
-}
-
 const ENTRIES_QUERY = `
   {
     allDoczEntries{
@@ -41,7 +37,7 @@ module.exports = ({ graphql, actions }, opts) => {
       const component = path.join(paths.root, entry.filepath)
       actions.createPage({
         component,
-        path: mountRoute(config.base, entry.route),
+        path: entry.route,
         context: {
           entry,
         },


### PR DESCRIPTION
Entry routes already include the base (as of 9ca39d7), so
adding it during page creation was creating bad paths,
i.e., given config like `{base: '/base/'}`, paths would become
`/base//base/entry-slug`.

This fix simply removes the concatenation of the entry routes to
the base path, under the assumption that the entry route
already includes the base path.
