### PR TITLE
filterComponents only works with capitalized files (Button.tsx, etc)

### DIFF
--- a/core/docz-core/src/config/docz.ts
+++ b/core/docz-core/src/config/docz.ts
@@ -21,7 +21,7 @@ export const doczRcBaseConfig = {
   themeConfig: {},
   docgenConfig: {},
   filterComponents: (files: string[]) =>
-    files.filter(filepath => /\/[A-Z]\w*\.(js|jsx|ts|tsx)$/.test(filepath)),
+    files.filter(filepath => /\/\w*\.(js|jsx|ts|tsx)$/.test(filepath)),
   modifyBundlerConfig: (config: any) => config,
   modifyBabelRc: (babelrc: BabelRC) => babelrc,
   onCreateWebpackChain: () => null,


### PR DESCRIPTION
### Description

filterComponents only works with capitalized files (Button.tsx, etc). But a lot of people use seperate folder and `index.*` for their components. If current behaviour is expected then I think it should be in documentation (I haven't found in Project configuration section)

P.S. it should be in documentation any way