### PR TITLE
feat(docz-theme-default): add RunKit for code block

### DIFF
--- a/core/docz-core/src/config/argv.ts
+++ b/core/docz-core/src/config/argv.ts
@@ -73,7 +73,6 @@ export interface Argv {
   websocketHost: string
   native: boolean
   codeSandbox: boolean
-  runKit: boolean
   sourcemaps: boolean
   /* template args */
   title: string
@@ -86,6 +85,7 @@ export interface Argv {
 }
 
 export interface Config extends Argv {
+  runKit: boolean
   paths: Record<string, any>
   plugins: Plugin[]
   mdPlugins: any[]
@@ -200,10 +200,6 @@ export const setArgs = (yargs: Yargs) => {
     .option('codeSandbox', {
       type: 'boolean',
       default: getEnv('docz.codeSandbox', true),
-    })
-    .option('runKit', {
-      type: 'boolean',
-      default: getEnv('docz.runKit', true),
     })
     .option('sourcemaps', {
       type: 'boolean',

--- a/core/docz-core/src/config/argv.ts
+++ b/core/docz-core/src/config/argv.ts
@@ -73,6 +73,7 @@ export interface Argv {
   websocketHost: string
   native: boolean
   codeSandbox: boolean
+  runKit: boolean
   sourcemaps: boolean
   /* template args */
   title: string
@@ -199,6 +200,10 @@ export const setArgs = (yargs: Yargs) => {
     .option('codeSandbox', {
       type: 'boolean',
       default: getEnv('docz.codeSandbox', true),
+    })
+    .option('runKit', {
+      type: 'boolean',
+      default: getEnv('docz.runKit', true),
     })
     .option('sourcemaps', {
       type: 'boolean',

--- a/core/docz-core/src/config/docz.ts
+++ b/core/docz-core/src/config/docz.ts
@@ -18,6 +18,7 @@ const htmlContext = {
 
 export const doczRcBaseConfig = {
   htmlContext,
+  runKit: false,
   themeConfig: {},
   docgenConfig: {},
   filterComponents: (files: string[]) =>

--- a/core/docz-core/src/states/config.ts
+++ b/core/docz-core/src/states/config.ts
@@ -17,7 +17,6 @@ interface Payload {
   repository: string | null
   native: boolean
   codeSandbox: boolean
-  runKit: boolean
   themeConfig: ThemeConfig
   separator: string
 }
@@ -34,7 +33,6 @@ const getInitialConfig = (config: Config): Payload => {
     repository: repoUrl,
     native: config.native,
     codeSandbox: config.codeSandbox,
-    runKit: config.runKit,
     themeConfig: config.themeConfig,
     separator: config.separator,
   }

--- a/core/docz-core/src/states/config.ts
+++ b/core/docz-core/src/states/config.ts
@@ -17,6 +17,7 @@ interface Payload {
   repository: string | null
   native: boolean
   codeSandbox: boolean
+  runKit: boolean
   themeConfig: ThemeConfig
   separator: string
 }
@@ -33,6 +34,7 @@ const getInitialConfig = (config: Config): Payload => {
     repository: repoUrl,
     native: config.native,
     codeSandbox: config.codeSandbox,
+    runKit: config.runKit,
     themeConfig: config.themeConfig,
     separator: config.separator,
   }

--- a/core/docz-core/src/utils/parse-html.ts
+++ b/core/docz-core/src/utils/parse-html.ts
@@ -10,6 +10,14 @@ import * as paths from '../config/paths'
 import { Config } from '../config/argv'
 import { fromTemplates } from '../lib/Entries'
 
+const runKitVendor = {
+  css: `<link href="https://fonts.googleapis.com/css?family=Fira+Sans:400,700|Ubuntu+Mono:400"
+  type="text/css"
+  rel="stylesheet"
+/>`,
+  js: '<script type="text/javascript" src="https://embed.runkit.com"></script>',
+}
+
 const wrapItems = (item: any) =>
   Object.keys(item)
     .map(key => `${key}="${item[key]}"`)
@@ -59,7 +67,7 @@ interface ParseHtmlParams {
 }
 
 export const parseHtml = ({ config, ctx, dev, template }: ParseHtmlParams) => {
-  const { title, description } = config
+  const { title, description, runKit } = config
   const {
     publicPath,
     css,
@@ -75,7 +83,9 @@ export const parseHtml = ({ config, ctx, dev, template }: ParseHtmlParams) => {
     ${favicon ? `<link rel="icon" type="image/x-icon" href="${favicon}">` : ''}
     ${head.meta ? generateMetaTags(head.meta) : ''}
     ${head.links ? generateLinkTags(head.links) : ''}
+    ${runKit ? runKitVendor.css : ''}
     ${head.raw ? generateRawTags(head.raw) : ''}
+    ${runKit ? runKitVendor.js : ''}
     ${head.scripts ? generateScriptTags(head.scripts) : ''}
     ${generateCSSReferences(css, publicPath)}`
 

--- a/core/docz-core/templates/index.tpl.html
+++ b/core/docz-core/templates/index.tpl.html
@@ -5,12 +5,6 @@
     <meta name="description" content="{{ description }}" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
-    <link
-      href="https://fonts.googleapis.com/css?family=Fira+Sans:400,700|Ubuntu+Mono:400"
-      type="text/css"
-      rel="stylesheet"
-    />
-    <script type="text/javascript" src="https://embed.runkit.com"></script>
 
     <title>{{ title }}</title>
     {{

--- a/core/docz-core/templates/index.tpl.html
+++ b/core/docz-core/templates/index.tpl.html
@@ -1,12 +1,21 @@
 <!DOCTYPE html>
 <html lang="{{ lang }}">
   <head>
-    <meta charset="UTF-8">
-    <meta name="description" content="{{ description }}">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <meta charset="UTF-8" />
+    <meta name="description" content="{{ description }}" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <link
+      href="https://fonts.googleapis.com/css?family=Fira+Sans:400,700|Ubuntu+Mono:400"
+      type="text/css"
+      rel="stylesheet"
+    />
+    <script type="text/javascript" src="https://embed.runkit.com"></script>
+
     <title>{{ title }}</title>
-    {{ head }}
+    {{
+      head
+    }}
   </head>
   <body>
     <div id="root"></div>

--- a/core/docz-theme-default/package.json
+++ b/core/docz-theme-default/package.json
@@ -38,6 +38,7 @@
     "react-feather": "^1.1.6",
     "react-live": "2.0.1",
     "react-perfect-scrollbar": "^1.5.0",
+    "react-runkit": "^0.9.0",
     "styled-components": "^4.2.0"
   },
   "peerDependencies": {

--- a/core/docz-theme-default/src/components/ui/Editor/elements.tsx
+++ b/core/docz-theme-default/src/components/ui/Editor/elements.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { SFC } from 'react'
 import BaseCheck from 'react-feather/dist/icons/check'
 import Clipboard from 'react-feather/dist/icons/clipboard'
+import Code from 'react-feather/dist/icons/code'
 import rgba from 'polished/lib/color/rgba'
 import copy from 'copy-text-to-clipboard'
 import styled from 'styled-components'
@@ -29,12 +30,23 @@ export const ActionButton = styled(ButtonSwap)`
   }
 `
 
+export const RunKitTextLogo = styled.span`
+  font-family: 'Fira Sans', sans-serif;
+  font-size: 13px;
+  font-weight: 700;
+  margin: 0 0 0 2px;
+`
+
 const Check = styled(BaseCheck)`
   stroke: ${get('colors.primary')};
 `
 
 interface ClipboardActionProps {
   content: string
+}
+
+interface PanelSwitchActionProps {
+  action: (...args: any[]) => void
 }
 
 export const ClipboardAction: SFC<ClipboardActionProps> = ({
@@ -48,5 +60,20 @@ export const ClipboardAction: SFC<ClipboardActionProps> = ({
     swap={<Check width={17} />}
   >
     <Clipboard width={15} />
+  </ActionButton>
+)
+
+export const RunKitAction: SFC<PanelSwitchActionProps> = ({
+  action,
+  ...props
+}) => (
+  <ActionButton
+    {...props}
+    title="Open in RunKit"
+    onClick={action}
+    swap={<Check width={17} />}
+  >
+    <Code width={15} />
+    <RunKitTextLogo> RunKit</RunKitTextLogo>
   </ActionButton>
 )

--- a/core/docz-theme-default/src/components/ui/Editor/index.tsx
+++ b/core/docz-theme-default/src/components/ui/Editor/index.tsx
@@ -4,8 +4,9 @@ import { useConfig, UseConfigObj } from 'docz'
 import loadable from '@loadable/component'
 import styled from 'styled-components'
 import getter from 'lodash/get'
+import Embed from 'react-runkit'
 
-import { ClipboardAction } from './elements'
+import { ClipboardAction, RunKitAction } from './elements'
 import { get } from '@utils/theme'
 
 const CodeMirror = loadable(() => import('../CodeMirror'))
@@ -42,7 +43,7 @@ const Actions = styled.div`
   top: 0;
   right: 0;
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   align-items: center;
   padding: 5px 10px;
   background: transparent;
@@ -62,6 +63,11 @@ export interface EditorProps {
   withLastLine?: boolean
 }
 
+enum Panels {
+  CODE_MIRROR,
+  RUN_KIT,
+}
+
 export const Editor: React.SFC<EditorProps> = ({
   mode,
   children,
@@ -73,8 +79,10 @@ export const Editor: React.SFC<EditorProps> = ({
   ...props
 }) => {
   const config = useConfig()
+  console.log(config)
   const initialCode = useMemo(() => getChildren(children), [children])
   const [code, setCode] = useState(initialCode)
+  const [panel, setPanel] = useState(Panels.CODE_MIRROR)
   const language = defaultLanguage || getLanguage(children)
   const options = {
     ...props,
@@ -122,10 +130,25 @@ export const Editor: React.SFC<EditorProps> = ({
     },
   })
 
-  return (
+  return panel === Panels.RUN_KIT ? (
+    <Embed source={code} />
+  ) : (
     <Wrapper className={className}>
       <CodeMirror {...editorProps(config)} />
-      <Actions>{actions || <ClipboardAction content={code} />}</Actions>
+      <Actions>
+        {actions || (
+          <React.Fragment>
+            <ClipboardAction content={code} />
+            {config.runKit ? (
+              <RunKitAction
+                action={() => {
+                  setPanel(Panels.RUN_KIT)
+                }}
+              />
+            ) : null}
+          </React.Fragment>
+        )}
+      </Actions>
     </Wrapper>
   )
 }

--- a/core/docz-theme-default/src/components/ui/Editor/index.tsx
+++ b/core/docz-theme-default/src/components/ui/Editor/index.tsx
@@ -79,7 +79,6 @@ export const Editor: React.SFC<EditorProps> = ({
   ...props
 }) => {
   const config = useConfig()
-  console.log(config)
   const initialCode = useMemo(() => getChildren(children), [children])
   const [code, setCode] = useState(initialCode)
   const [panel, setPanel] = useState(Panels.CODE_MIRROR)

--- a/core/docz-theme-default/tsconfig.json
+++ b/core/docz-theme-default/tsconfig.json
@@ -8,13 +8,17 @@
     "baseUrl": "src",
     "rootDir": "src",
     "outDir": "dist",
-    "typeRoots": ["../../node_modules/@types", "node_modules/@types"],
+    "typeRoots": [
+      "../../node_modules/@types",
+      "node_modules/@types",
+      "./typings"
+    ],
     "paths": {
       "@components/*": ["components/*"],
       "@styles/*": ["styles/*"],
       "@utils/*": ["utils/*"]
     }
   },
-  "include": ["src/**/*", "src/types"],
+  "include": ["src/**/*", "src/types", "typings"],
   "exclude": ["node_modules/**"]
 }

--- a/core/docz/src/state.tsx
+++ b/core/docz/src/state.tsx
@@ -41,6 +41,7 @@ export interface Config {
   native: boolean
   separator: string
   codeSandbox: boolean
+  runKit: boolean
 }
 
 export type Entries = Array<{ key: string; value: Entry }>

--- a/yarn.lock
+++ b/yarn.lock
@@ -14353,6 +14353,11 @@ react-perfect-scrollbar@^1.5.0:
     perfect-scrollbar "^1.4.0"
     prop-types "^15.6.1"
 
+react-runkit@^0.9.0:
+  version "0.9.0"
+  resolved "http://registry.npm.taobao.org/react-runkit/download/react-runkit-0.9.0.tgz#8a97aec60c2fcf9da17b0af2bb91a877e4336b05"
+  integrity sha1-ipeuxgwvz52hewryu5God+QzawU=
+
 react-side-effect@^1.1.0:
   version "1.1.5"
   resolved "https://registry.npmjs.org/react-side-effect/-/react-side-effect-1.1.5.tgz#f26059e50ed9c626d91d661b9f3c8bb38cd0ff2d"


### PR DESCRIPTION
### Description

Related roadmap: http://feedback.docz.site/roadmap/p/integration-with-runkit

Implement RunKit for code block. There is still some work to be done: 
- [x] dynamic inject the runkit vendor script. Now it's hard coded in html template.
- [x] better style for runkit text logo. I tried to import the `fira-sans` code but the minified html turn to be like `<linkhref="xxx" ..>`. May resolve it latter.

Any Suggestions for improvement? 🤗