### PR TITLE
fix(babel-plugin-export-metadata): fix re-export default (#790)

### DIFF
--- a/other-packages/babel-plugin-export-metadata/src/index.js
+++ b/other-packages/babel-plugin-export-metadata/src/index.js
@@ -50,12 +50,17 @@ const insertNodeExport = t => (path, state) => {
     addFileMetaProperties(t, path, filename, name)
   } else if (declarations) {
     for (declaration of declarations) {
-      declarationName = get(declaration, 'id.name')
+      const declarationName = get(declaration, 'id.name')
       addFileMetaProperties(t, path, filename, declarationName)
     }
   } else if (specifiers) {
     for (specifier of specifiers) {
-      specifierName = get(specifier, 'local.name')
+      let specifierName = get(specifier, 'local.name')
+      specifierName =
+        specifierName === 'default'
+          ? get(specifier, 'exported.name')
+          : specifierName
+
       addFileMetaProperties(t, path, filename, specifierName)
     }
   }


### PR DESCRIPTION
### Description

fix #790 
However, I think this is just a temp workaround. babel-plugin-export-metadata could have a better parse method with export.