### PR TITLE
Avoid adding __filemeta to non-extensible objects

### DIFF
--- a/other-packages/babel-plugin-export-metadata/src/index.js
+++ b/other-packages/babel-plugin-export-metadata/src/index.js
@@ -3,7 +3,7 @@ const { default: template } = require('@babel/template')
 const { get } = require('lodash')
 
 const buildFileMeta = template(`
-  if (typeof ID !== 'undefined' && ID && ID === Object(ID)) {
+  if (typeof ID !== 'undefined' && ID && ID === Object(ID) && Object.isExtensible(ID)) {
     Object.defineProperty(ID, '__filemeta', {
       enumerable: true,
       configurable: true,


### PR DESCRIPTION
### Description

Currently, the `__filemeta` property is added to all exports, even if they are not extensible, which causes an error at runtime, as detailed in #795.  This only executes the `Object.defineProperty` call if the object is extensible (i.e. `Object.isExtensible(ID) == true`)

Fixes #795 