### PR TITLE
chore: disable dev server host check

### DIFF
--- a/core/docz-core/src/bundler/devserver.ts
+++ b/core/docz-core/src/bundler/devserver.ts
@@ -32,6 +32,7 @@ export const devServerConfig = (hooks: ServerHooks, args: Args) => {
     historyApiFallback: {
       disableDotRule: true,
     },
+    disableHostCheck: true,
     before(app: any, server: any): void {
       app.use('/public', express.static(publicDir))
       app.use(evalSourceMapMiddleware(server))


### PR DESCRIPTION
### Description

Can we disable the host check for online IDE's like Amazon Cloud9?