### PR TITLE
fix(babel-plugin-export-metadata): re-export causes meta error

### DIFF
--- a/other-packages/babel-plugin-export-metadata/tests/__snapshots__/index.test.js.snap
+++ b/other-packages/babel-plugin-export-metadata/tests/__snapshots__/index.test.js.snap
@@ -220,17 +220,6 @@ if (typeof __DOCZ_DUMMY_EXPORT_DEFAULT !== 'undefined' && __DOCZ_DUMMY_EXPORT_DE
       filename: \\"tests/fixtures/re-export/re-export-default.js\\"
     }
   });
-}
-
-if (typeof __DOCZ_DUMMY_EXPORT_DEFAULT !== 'undefined' && __DOCZ_DUMMY_EXPORT_DEFAULT && __DOCZ_DUMMY_EXPORT_DEFAULT === Object(__DOCZ_DUMMY_EXPORT_DEFAULT) && Object.isExtensible(__DOCZ_DUMMY_EXPORT_DEFAULT)) {
-  Object.defineProperty(__DOCZ_DUMMY_EXPORT_DEFAULT, '__filemeta', {
-    enumerable: true,
-    configurable: true,
-    value: {
-      name: \\"__DOCZ_DUMMY_EXPORT_DEFAULT\\",
-      filename: \\"tests/fixtures/re-export/re-export-default.js\\"
-    }
-  });
 }"
 `;
 
@@ -268,14 +257,15 @@ if (typeof a !== 'undefined' && a && a === Object(a) && Object.isExtensible(a)) 
 
 exports[`export-metadata re-export re export name to default 1`] = `
 "/* Re-export  */
-export { a as aDefault } from '../assets/a';
+import a from \\"../assets/a\\";
+export default a;
 
-if (typeof aDefault !== 'undefined' && aDefault && aDefault === Object(aDefault) && Object.isExtensible(aDefault)) {
-  Object.defineProperty(aDefault, '__filemeta', {
+if (typeof a !== 'undefined' && a && a === Object(a) && Object.isExtensible(a)) {
+  Object.defineProperty(a, '__filemeta', {
     enumerable: true,
     configurable: true,
     value: {
-      name: \\"aDefault\\",
+      name: \\"a\\",
       filename: \\"tests/fixtures/re-export/re-export-rename2.js\\"
     }
   });

--- a/other-packages/babel-plugin-export-metadata/tests/__snapshots__/index.test.js.snap
+++ b/other-packages/babel-plugin-export-metadata/tests/__snapshots__/index.test.js.snap
@@ -205,3 +205,97 @@ if (typeof Bar2 !== 'undefined' && Bar2 && Bar2 === Object(Bar2)) {
   });
 }"
 `;
+
+exports[`export-metadata re-export re export default 1`] = `
+"/* Re-export  */
+import __DOCZ_DUMMY_EXPORT_DEFAULT from \\"../assets/a\\";
+export default __DOCZ_DUMMY_EXPORT_DEFAULT;
+
+if (typeof __DOCZ_DUMMY_EXPORT_DEFAULT !== 'undefined' && __DOCZ_DUMMY_EXPORT_DEFAULT && __DOCZ_DUMMY_EXPORT_DEFAULT === Object(__DOCZ_DUMMY_EXPORT_DEFAULT)) {
+  Object.defineProperty(__DOCZ_DUMMY_EXPORT_DEFAULT, '__filemeta', {
+    enumerable: true,
+    configurable: true,
+    value: {
+      name: \\"__DOCZ_DUMMY_EXPORT_DEFAULT\\",
+      filename: \\"tests/fixtures/re-export/re-export-default.js\\"
+    }
+  });
+}
+
+if (typeof __DOCZ_DUMMY_EXPORT_DEFAULT !== 'undefined' && __DOCZ_DUMMY_EXPORT_DEFAULT && __DOCZ_DUMMY_EXPORT_DEFAULT === Object(__DOCZ_DUMMY_EXPORT_DEFAULT)) {
+  Object.defineProperty(__DOCZ_DUMMY_EXPORT_DEFAULT, '__filemeta', {
+    enumerable: true,
+    configurable: true,
+    value: {
+      name: \\"__DOCZ_DUMMY_EXPORT_DEFAULT\\",
+      filename: \\"tests/fixtures/re-export/re-export-default.js\\"
+    }
+  });
+}"
+`;
+
+exports[`export-metadata re-export re export default to name 1`] = `
+"/* Re-export  */
+export { default as aDefault } from '../assets/a';
+
+if (typeof aDefault !== 'undefined' && aDefault && aDefault === Object(aDefault)) {
+  Object.defineProperty(aDefault, '__filemeta', {
+    enumerable: true,
+    configurable: true,
+    value: {
+      name: \\"aDefault\\",
+      filename: \\"tests/fixtures/re-export/re-export-rename1.js\\"
+    }
+  });
+}"
+`;
+
+exports[`export-metadata re-export re export name 1`] = `
+"/* Re-export  */
+export { a } from '../assets/a';
+
+if (typeof a !== 'undefined' && a && a === Object(a)) {
+  Object.defineProperty(a, '__filemeta', {
+    enumerable: true,
+    configurable: true,
+    value: {
+      name: \\"a\\",
+      filename: \\"tests/fixtures/re-export/re-export.js\\"
+    }
+  });
+}"
+`;
+
+exports[`export-metadata re-export re export name to default 1`] = `
+"/* Re-export  */
+export { a as aDefault } from '../assets/a';
+
+if (typeof aDefault !== 'undefined' && aDefault && aDefault === Object(aDefault)) {
+  Object.defineProperty(aDefault, '__filemeta', {
+    enumerable: true,
+    configurable: true,
+    value: {
+      name: \\"aDefault\\",
+      filename: \\"tests/fixtures/re-export/re-export-rename2.js\\"
+    }
+  });
+}"
+`;
+
+exports[`export-metadata re-export re export name to name 1`] = `
+"/* Re-export  */
+export { a as aa } from '../assets/a';
+
+if (typeof aa !== 'undefined' && aa && aa === Object(aa)) {
+  Object.defineProperty(aa, '__filemeta', {
+    enumerable: true,
+    configurable: true,
+    value: {
+      name: \\"aa\\",
+      filename: \\"tests/fixtures/re-export/re-export-rename3.js\\"
+    }
+  });
+}"
+`;
+
+exports[`export-metadata re-export re-export default 1`] = `""`;

--- a/other-packages/babel-plugin-export-metadata/tests/__snapshots__/index.test.js.snap
+++ b/other-packages/babel-plugin-export-metadata/tests/__snapshots__/index.test.js.snap
@@ -8,7 +8,7 @@ let bar5 = () => {};
 
 export default [foo5, bar5];
 
-if (typeof bar5 !== 'undefined' && bar5 && bar5 === Object(bar5)) {
+if (typeof bar5 !== 'undefined' && bar5 && bar5 === Object(bar5) && Object.isExtensible(bar5)) {
   Object.defineProperty(bar5, '__filemeta', {
     enumerable: true,
     configurable: true,
@@ -19,7 +19,7 @@ if (typeof bar5 !== 'undefined' && bar5 && bar5 === Object(bar5)) {
   });
 }
 
-if (typeof foo5 !== 'undefined' && foo5 && foo5 === Object(foo5)) {
+if (typeof foo5 !== 'undefined' && foo5 && foo5 === Object(foo5) && Object.isExtensible(foo5)) {
   Object.defineProperty(foo5, '__filemeta', {
     enumerable: true,
     configurable: true,
@@ -35,7 +35,7 @@ exports[`export-metadata export default works with Class declaration 1`] = `
 "/* ExportDefaultDeclaration with Class declaration */
 export default class Bar6 {}
 
-if (typeof Bar6 !== 'undefined' && Bar6 && Bar6 === Object(Bar6)) {
+if (typeof Bar6 !== 'undefined' && Bar6 && Bar6 === Object(Bar6) && Object.isExtensible(Bar6)) {
   Object.defineProperty(Bar6, '__filemeta', {
     enumerable: true,
     configurable: true,
@@ -51,7 +51,7 @@ exports[`export-metadata export default works with Function declaration 1`] = `
 "/* ExportDefaultDeclaration with Function declaration */
 export default function foo6() {}
 
-if (typeof foo6 !== 'undefined' && foo6 && foo6 === Object(foo6)) {
+if (typeof foo6 !== 'undefined' && foo6 && foo6 === Object(foo6) && Object.isExtensible(foo6)) {
   Object.defineProperty(foo6, '__filemeta', {
     enumerable: true,
     configurable: true,
@@ -68,7 +68,7 @@ exports[`export-metadata export default works with Identifier 1`] = `
 let foo3 = 5;
 export default foo3;
 
-if (typeof foo3 !== 'undefined' && foo3 && foo3 === Object(foo3)) {
+if (typeof foo3 !== 'undefined' && foo3 && foo3 === Object(foo3) && Object.isExtensible(foo3)) {
   Object.defineProperty(foo3, '__filemeta', {
     enumerable: true,
     configurable: true,
@@ -87,7 +87,7 @@ export default {
   bar4: () => {}
 };
 
-if (typeof bar4 !== 'undefined' && bar4 && bar4 === Object(bar4)) {
+if (typeof bar4 !== 'undefined' && bar4 && bar4 === Object(bar4) && Object.isExtensible(bar4)) {
   Object.defineProperty(bar4, '__filemeta', {
     enumerable: true,
     configurable: true,
@@ -98,7 +98,7 @@ if (typeof bar4 !== 'undefined' && bar4 && bar4 === Object(bar4)) {
   });
 }
 
-if (typeof foo4 !== 'undefined' && foo4 && foo4 === Object(foo4)) {
+if (typeof foo4 !== 'undefined' && foo4 && foo4 === Object(foo4) && Object.isExtensible(foo4)) {
   Object.defineProperty(foo4, '__filemeta', {
     enumerable: true,
     configurable: true,
@@ -120,7 +120,7 @@ let baz = 'baz';
 export { foo as default, bar as foobar, baz };
 /* ExportNamedDeclaration with Variable declarations */
 
-if (typeof baz !== 'undefined' && baz && baz === Object(baz)) {
+if (typeof baz !== 'undefined' && baz && baz === Object(baz) && Object.isExtensible(baz)) {
   Object.defineProperty(baz, '__filemeta', {
     enumerable: true,
     configurable: true,
@@ -131,7 +131,7 @@ if (typeof baz !== 'undefined' && baz && baz === Object(baz)) {
   });
 }
 
-if (typeof bar !== 'undefined' && bar && bar === Object(bar)) {
+if (typeof bar !== 'undefined' && bar && bar === Object(bar) && Object.isExtensible(bar)) {
   Object.defineProperty(bar, '__filemeta', {
     enumerable: true,
     configurable: true,
@@ -142,7 +142,7 @@ if (typeof bar !== 'undefined' && bar && bar === Object(bar)) {
   });
 }
 
-if (typeof foo !== 'undefined' && foo && foo === Object(foo)) {
+if (typeof foo !== 'undefined' && foo && foo === Object(foo) && Object.isExtensible(foo)) {
   Object.defineProperty(foo, '__filemeta', {
     enumerable: true,
     configurable: true,
@@ -157,7 +157,7 @@ export let foo1 = 5,
     bar1 = () => {};
 /* ExportNamedDeclaration with Function and Class declarations */
 
-if (typeof bar1 !== 'undefined' && bar1 && bar1 === Object(bar1)) {
+if (typeof bar1 !== 'undefined' && bar1 && bar1 === Object(bar1) && Object.isExtensible(bar1)) {
   Object.defineProperty(bar1, '__filemeta', {
     enumerable: true,
     configurable: true,
@@ -168,7 +168,7 @@ if (typeof bar1 !== 'undefined' && bar1 && bar1 === Object(bar1)) {
   });
 }
 
-if (typeof foo1 !== 'undefined' && foo1 && foo1 === Object(foo1)) {
+if (typeof foo1 !== 'undefined' && foo1 && foo1 === Object(foo1) && Object.isExtensible(foo1)) {
   Object.defineProperty(foo1, '__filemeta', {
     enumerable: true,
     configurable: true,
@@ -181,7 +181,7 @@ if (typeof foo1 !== 'undefined' && foo1 && foo1 === Object(foo1)) {
 
 export function foo2() {}
 
-if (typeof foo2 !== 'undefined' && foo2 && foo2 === Object(foo2)) {
+if (typeof foo2 !== 'undefined' && foo2 && foo2 === Object(foo2) && Object.isExtensible(foo2)) {
   Object.defineProperty(foo2, '__filemeta', {
     enumerable: true,
     configurable: true,
@@ -194,7 +194,7 @@ if (typeof foo2 !== 'undefined' && foo2 && foo2 === Object(foo2)) {
 
 export class Bar2 {}
 
-if (typeof Bar2 !== 'undefined' && Bar2 && Bar2 === Object(Bar2)) {
+if (typeof Bar2 !== 'undefined' && Bar2 && Bar2 === Object(Bar2) && Object.isExtensible(Bar2)) {
   Object.defineProperty(Bar2, '__filemeta', {
     enumerable: true,
     configurable: true,
@@ -211,7 +211,7 @@ exports[`export-metadata re-export re export default 1`] = `
 import __DOCZ_DUMMY_EXPORT_DEFAULT from \\"../assets/a\\";
 export default __DOCZ_DUMMY_EXPORT_DEFAULT;
 
-if (typeof __DOCZ_DUMMY_EXPORT_DEFAULT !== 'undefined' && __DOCZ_DUMMY_EXPORT_DEFAULT && __DOCZ_DUMMY_EXPORT_DEFAULT === Object(__DOCZ_DUMMY_EXPORT_DEFAULT)) {
+if (typeof __DOCZ_DUMMY_EXPORT_DEFAULT !== 'undefined' && __DOCZ_DUMMY_EXPORT_DEFAULT && __DOCZ_DUMMY_EXPORT_DEFAULT === Object(__DOCZ_DUMMY_EXPORT_DEFAULT) && Object.isExtensible(__DOCZ_DUMMY_EXPORT_DEFAULT)) {
   Object.defineProperty(__DOCZ_DUMMY_EXPORT_DEFAULT, '__filemeta', {
     enumerable: true,
     configurable: true,
@@ -222,7 +222,7 @@ if (typeof __DOCZ_DUMMY_EXPORT_DEFAULT !== 'undefined' && __DOCZ_DUMMY_EXPORT_DE
   });
 }
 
-if (typeof __DOCZ_DUMMY_EXPORT_DEFAULT !== 'undefined' && __DOCZ_DUMMY_EXPORT_DEFAULT && __DOCZ_DUMMY_EXPORT_DEFAULT === Object(__DOCZ_DUMMY_EXPORT_DEFAULT)) {
+if (typeof __DOCZ_DUMMY_EXPORT_DEFAULT !== 'undefined' && __DOCZ_DUMMY_EXPORT_DEFAULT && __DOCZ_DUMMY_EXPORT_DEFAULT === Object(__DOCZ_DUMMY_EXPORT_DEFAULT) && Object.isExtensible(__DOCZ_DUMMY_EXPORT_DEFAULT)) {
   Object.defineProperty(__DOCZ_DUMMY_EXPORT_DEFAULT, '__filemeta', {
     enumerable: true,
     configurable: true,
@@ -238,7 +238,7 @@ exports[`export-metadata re-export re export default to name 1`] = `
 "/* Re-export  */
 export { default as aDefault } from '../assets/a';
 
-if (typeof aDefault !== 'undefined' && aDefault && aDefault === Object(aDefault)) {
+if (typeof aDefault !== 'undefined' && aDefault && aDefault === Object(aDefault) && Object.isExtensible(aDefault)) {
   Object.defineProperty(aDefault, '__filemeta', {
     enumerable: true,
     configurable: true,
@@ -254,7 +254,7 @@ exports[`export-metadata re-export re export name 1`] = `
 "/* Re-export  */
 export { a } from '../assets/a';
 
-if (typeof a !== 'undefined' && a && a === Object(a)) {
+if (typeof a !== 'undefined' && a && a === Object(a) && Object.isExtensible(a)) {
   Object.defineProperty(a, '__filemeta', {
     enumerable: true,
     configurable: true,
@@ -270,7 +270,7 @@ exports[`export-metadata re-export re export name to default 1`] = `
 "/* Re-export  */
 export { a as aDefault } from '../assets/a';
 
-if (typeof aDefault !== 'undefined' && aDefault && aDefault === Object(aDefault)) {
+if (typeof aDefault !== 'undefined' && aDefault && aDefault === Object(aDefault) && Object.isExtensible(aDefault)) {
   Object.defineProperty(aDefault, '__filemeta', {
     enumerable: true,
     configurable: true,
@@ -286,7 +286,7 @@ exports[`export-metadata re-export re export name to name 1`] = `
 "/* Re-export  */
 export { a as aa } from '../assets/a';
 
-if (typeof aa !== 'undefined' && aa && aa === Object(aa)) {
+if (typeof aa !== 'undefined' && aa && aa === Object(aa) && Object.isExtensible(aa)) {
   Object.defineProperty(aa, '__filemeta', {
     enumerable: true,
     configurable: true,

--- a/other-packages/babel-plugin-export-metadata/tests/fixtures/assets/a.js
+++ b/other-packages/babel-plugin-export-metadata/tests/fixtures/assets/a.js
@@ -1,0 +1,4 @@
+const a = 1
+const ____a = 2
+export { a }
+export default ____a

--- a/other-packages/babel-plugin-export-metadata/tests/fixtures/re-export/re-export-default.js
+++ b/other-packages/babel-plugin-export-metadata/tests/fixtures/re-export/re-export-default.js
@@ -1,0 +1,2 @@
+/* Re-export  */
+export { default } from '../assets/a'

--- a/other-packages/babel-plugin-export-metadata/tests/fixtures/re-export/re-export-multi.js
+++ b/other-packages/babel-plugin-export-metadata/tests/fixtures/re-export/re-export-multi.js
@@ -1,0 +1,2 @@
+/* Re-export  */
+export aDefault, { a } from '../assets/a'

--- a/other-packages/babel-plugin-export-metadata/tests/fixtures/re-export/re-export-rename1.js
+++ b/other-packages/babel-plugin-export-metadata/tests/fixtures/re-export/re-export-rename1.js
@@ -1,0 +1,2 @@
+/* Re-export  */
+export { default as aDefault } from '../assets/a'

--- a/other-packages/babel-plugin-export-metadata/tests/fixtures/re-export/re-export-rename2.js
+++ b/other-packages/babel-plugin-export-metadata/tests/fixtures/re-export/re-export-rename2.js
@@ -1,0 +1,2 @@
+/* Re-export  */
+export { a as aDefault } from '../assets/a'

--- a/other-packages/babel-plugin-export-metadata/tests/fixtures/re-export/re-export-rename2.js
+++ b/other-packages/babel-plugin-export-metadata/tests/fixtures/re-export/re-export-rename2.js
@@ -1,2 +1,2 @@
 /* Re-export  */
-export { a as aDefault } from '../assets/a'
+export { a as default } from '../assets/a'

--- a/other-packages/babel-plugin-export-metadata/tests/fixtures/re-export/re-export-rename3.js
+++ b/other-packages/babel-plugin-export-metadata/tests/fixtures/re-export/re-export-rename3.js
@@ -1,0 +1,2 @@
+/* Re-export  */
+export { a as aa } from '../assets/a'

--- a/other-packages/babel-plugin-export-metadata/tests/fixtures/re-export/re-export.js
+++ b/other-packages/babel-plugin-export-metadata/tests/fixtures/re-export/re-export.js
@@ -1,0 +1,2 @@
+/* Re-export  */
+export { a } from '../assets/a'

--- a/other-packages/babel-plugin-export-metadata/tests/index.test.js
+++ b/other-packages/babel-plugin-export-metadata/tests/index.test.js
@@ -6,6 +6,7 @@ const plugin = require('../src')
 const exportNamedFixture = path.resolve(
   './tests/fixtures/export-named/index.js'
 )
+
 const exportDefaultFixtures = {
   withArrExpression: path.resolve(
     './tests/fixtures/export-default/with-arr-expression.js'
@@ -24,17 +25,49 @@ const exportDefaultFixtures = {
   ),
 }
 
-const exportDefaultCode = Object.keys(exportDefaultFixtures).reduce(
-  (acc, key) => ({
-    ...acc,
-    [key]: fs.readFileSync(exportDefaultFixtures[key]).toString(),
-  }),
-  {}
-)
+const reExportsFixtures = {
+  reExportName: path.resolve(
+    path.resolve('./tests/fixtures/re-export/re-export.js')
+  ),
+  reExportDefault: path.resolve(
+    path.resolve('./tests/fixtures/re-export/re-export-default.js')
+  ),
+  reExportDefaultToName: path.resolve(
+    path.resolve('./tests/fixtures/re-export/re-export-rename1.js')
+  ),
+  reExportNameToDefault: path.resolve(
+    path.resolve('./tests/fixtures/re-export/re-export-rename2.js')
+  ),
+  reExportNameToName: path.resolve(
+    path.resolve('./tests/fixtures/re-export/re-export-rename3.js')
+  ),
+}
 
+const getCodeFromFilePath = paths =>
+  Object.keys(paths).reduce(
+    (acc, key) => ({
+      ...acc,
+      [key]: fs.readFileSync(paths[key]).toString(),
+    }),
+    {}
+  )
+
+const exportDefaultCode = getCodeFromFilePath(exportDefaultFixtures)
 const exportNamedCode = fs.readFileSync(exportNamedFixture).toString()
+const reExportCode = getCodeFromFilePath(reExportsFixtures)
 
 describe('export-metadata', () => {
+  describe('re-export', () => {
+    it('re-export default', () => {
+      const result = transformSync(exportDefaultFixtures.reExportName, {
+        plugins: [plugin],
+        filename: exportNamedFixture.reExportName,
+      })
+
+      expect(result.code).toMatchSnapshot()
+    })
+  })
+
   describe('export default', () => {
     it('works with Array expression', () => {
       const result = transformSync(exportDefaultCode.withArrExpression, {
@@ -87,6 +120,53 @@ describe('export-metadata', () => {
       const result = transformSync(exportNamedCode, {
         plugins: [plugin],
         filename: exportNamedFixture,
+      })
+
+      expect(result.code).toMatchSnapshot()
+    })
+  })
+
+  describe('re-export', () => {
+    it('re export name', () => {
+      const result = transformSync(reExportCode.reExportName, {
+        plugins: [plugin],
+        filename: reExportsFixtures.reExportName,
+      })
+
+      expect(result.code).toMatchSnapshot()
+    })
+
+    it('re export default', () => {
+      const result = transformSync(reExportCode.reExportDefault, {
+        plugins: [plugin],
+        filename: reExportsFixtures.reExportDefault,
+      })
+
+      expect(result.code).toMatchSnapshot()
+    })
+
+    it('re export name to default', () => {
+      const result = transformSync(reExportCode.reExportNameToDefault, {
+        plugins: [plugin],
+        filename: reExportsFixtures.reExportNameToDefault,
+      })
+
+      expect(result.code).toMatchSnapshot()
+    })
+
+    it('re export default to name', () => {
+      const result = transformSync(reExportCode.reExportDefaultToName, {
+        plugins: [plugin],
+        filename: reExportsFixtures.reExportDefaultToName,
+      })
+
+      expect(result.code).toMatchSnapshot()
+    })
+
+    it('re export name to name', () => {
+      const result = transformSync(reExportCode.reExportNameToName, {
+        plugins: [plugin],
+        filename: reExportsFixtures.reExportNameToName,
       })
 
       expect(result.code).toMatchSnapshot()


### PR DESCRIPTION
### Description
This PR could fix #794 . @pedronauck 
Fix re-export caused error. Following re-export are fixed: 

```js
export { default } from './a'

export { a } from './a'

export { default as b } from './a'

export { a as default } from './a'

export { a as b } from './a'

```


### Review

- [x] add tests