### PR TITLE
chore: sidebar - use window.innerWidth for breakpoint detection

### DIFF
--- a/core/docz-theme-default/src/components/shared/Sidebar/index.tsx
+++ b/core/docz-theme-default/src/components/shared/Sidebar/index.tsx
@@ -120,7 +120,7 @@ export const Sidebar: SFC = () => {
   const [query, setQuery] = useState('')
   const menus = useMenus({ query })
   const windowSize = useWindowSize()
-  const isDesktop = windowSize.outerWidth >= breakpoints.desktop
+  const isDesktop = windowSize.innerWidth >= breakpoints.desktop
   const prevIsDesktop = usePrevious(isDesktop)
 
   useEffect(() => {


### PR DESCRIPTION
### Description

The sidebar doesn't work if the browser window is small due to opened developer tools 