### PR TITLE
feat(docz-core): add params to support dev server in the cloud

### DIFF
--- a/core/docz-core/src/bundler/devserver.ts
+++ b/core/docz-core/src/bundler/devserver.ts
@@ -29,10 +29,9 @@ export const devServerConfig = (hooks: ServerHooks, args: Args) => {
     // folder we won't consider accessing them a vulnerability. However, if you
     // use the `proxy` feature, it gets more dangerous because it can expose
     // remote code execution vulnerabilities in backends like Django and Rails.
-    // So we will disable the host check normally, but enable it if you have
-    // specified the `proxy` setting. Finally, we let you override it if you
-    // really know what you're doing with a special environment variable.
-    disableHostCheck: !args.proxy || args.disableHostCheck === 'true',
+    // So we will enable the host check normally. We let you override it if you
+    // really know what you're doing with `--disableHostCheck="true"`
+    disableHostCheck: args.disableHostCheck === 'true',
     publicPath: '/',
     compress: true,
     logLevel: args.debug ? 'debug' : 'silent',

--- a/core/docz-core/src/bundler/devserver.ts
+++ b/core/docz-core/src/bundler/devserver.ts
@@ -14,6 +14,25 @@ export const devServerConfig = (hooks: ServerHooks, args: Args) => {
   const nonExistentDir = path.resolve(__dirname, 'non-existent')
 
   return {
+    // Comment from react scripts
+    // https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/config/webpackDevServer.config.js#L22
+    // WebpackDevServer 2.4.3 introduced a security fix that prevents remote
+    // websites from potentially accessing local content through DNS rebinding:
+    // https://github.com/webpack/webpack-dev-server/issues/887
+    // https://medium.com/webpack/webpack-dev-server-middleware-security-issues-1489d950874a
+    // However, it made several existing use cases such as development in cloud
+    // environment or subdomains in development significantly more complicated:
+    // https://github.com/facebook/create-react-app/issues/2271
+    // https://github.com/facebook/create-react-app/issues/2233
+    // While we're investigating better solutions, for now we will take a
+    // compromise. Since our WDS configuration only serves files in the `public`
+    // folder we won't consider accessing them a vulnerability. However, if you
+    // use the `proxy` feature, it gets more dangerous because it can expose
+    // remote code execution vulnerabilities in backends like Django and Rails.
+    // So we will disable the host check normally, but enable it if you have
+    // specified the `proxy` setting. Finally, we let you override it if you
+    // really know what you're doing with a special environment variable.
+    disableHostCheck: !args.proxy || args.disableHostCheck === 'true',
     publicPath: '/',
     compress: true,
     logLevel: args.debug ? 'debug' : 'silent',

--- a/core/docz-core/src/config/argv.ts
+++ b/core/docz-core/src/config/argv.ts
@@ -68,7 +68,6 @@ export interface Argv {
   typescript: boolean
   propsParser: boolean
   host: string
-  proxy: string
   disableHostCheck: string
   port: number
   websocketPort: number

--- a/core/docz-core/src/config/argv.ts
+++ b/core/docz-core/src/config/argv.ts
@@ -68,6 +68,8 @@ export interface Argv {
   typescript: boolean
   propsParser: boolean
   host: string
+  proxy: string
+  disableHostCheck: string
   port: number
   websocketPort: number
   websocketHost: string


### PR DESCRIPTION
### Description

I do a fair amount of developmnent in the cloud. The current version does not work in the cloud do to a localhost secuirity fix in webpack. I look at how create react app solved and issue and more or less borrowed what they did.
