### PR TITLE
refactor(docz-rollup): win tolerant (rollup-plugin-peer-deps-external)

### DIFF
--- a/core/docz-rollup/package.json
+++ b/core/docz-rollup/package.json
@@ -21,6 +21,7 @@
     "lodash": "^4.17.11",
     "log-update": "^3.2.0",
     "rollup": "^1.10.0",
-    "rollup-plugin-babel": "^4.3.2"
+    "rollup-plugin-babel": "^4.3.2",
+    "rollup-plugin-peer-deps-external": "^2.2.0"
   }
 }

--- a/core/docz-rollup/src/index.js
+++ b/core/docz-rollup/src/index.js
@@ -1,21 +1,14 @@
 const { omit, get } = require('lodash')
 const typescript = require('@pedronauck/rollup-plugin-typescript2')
 const babel = require('rollup-plugin-babel')
+const peerDepsExternal = require('rollup-plugin-peer-deps-external')
 
 const sizePlugin = require('./plugins/size')
 const copyPlugin = require('./plugins/copy')
 
-const defaultExternal = id => {
-  return (
-    !id.startsWith('\0') &&
-    !id.startsWith('.') &&
-    !id.startsWith(process.platform === 'win32' ? process.cwd() : '/')
-  )
-}
-
 const output = (format, outputDir, { plugins = [], external, ...opts }) => ({
   ...opts,
-  external: external || defaultExternal,
+  external,
   output: {
     format,
     dir: outputDir,
@@ -23,6 +16,9 @@ const output = (format, outputDir, { plugins = [], external, ...opts }) => ({
     entryFileNames: `[name]${format !== 'cjs' ? '.[format]' : ''}.js`,
   },
   plugins: [
+    peerDepsExternal({
+      includeDependencies: true,
+    }),
     babel({
       exclude: 'node_modules/**',
       runtimeHelpers: false,

--- a/core/docz-theme-default/rollup.config.js
+++ b/core/docz-theme-default/rollup.config.js
@@ -3,9 +3,6 @@ import { config } from 'docz-rollup'
 export default config({
   input: 'src/index.tsx',
   external: id =>
-    !id.startsWith('\0') &&
-    !id.startsWith('.') &&
-    !id.startsWith(process.platform === 'win32' ? process.cwd() : '/') &&
     !id.startsWith('@components') &&
     !id.startsWith('@utils') &&
     !id.startsWith('@styles'),

--- a/core/docz/rollup.config.js
+++ b/core/docz/rollup.config.js
@@ -1,9 +1,5 @@
 import { config } from 'docz-rollup'
 
 export default config({
-  input: 'src/index.ts',
-  external: id =>
-    !id.startsWith('\0') &&
-    !id.startsWith('.') &&
-    !id.startsWith(process.platform === 'win32' ? process.cwd() : '/')
+  input: 'src/index.ts'
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -15219,6 +15219,11 @@ rollup-plugin-babel@^4.3.2:
     "@babel/helper-module-imports" "^7.0.0"
     rollup-pluginutils "^2.3.0"
 
+rollup-plugin-peer-deps-external@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-peer-deps-external/-/rollup-plugin-peer-deps-external-2.2.0.tgz#99ef9231aa01736f3e9605b7c3084a0d627f665b"
+  integrity sha512-BmJMHUWQcvjS2dQMwJ7dzvdbwpRChnq4AYk2sTU/4aySt9Kumk8y8W3HhTHss31wxzKb0AC/wsiX1AqDcOBIEA==
+
 rollup-pluginutils@2.3.3:
   version "2.3.3"
   resolved "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.3.3.tgz#3aad9b1eb3e7fe8262820818840bf091e5ae6794"


### PR DESCRIPTION
Fix for [#783](https://github.com/pedronauck/docz/issues/783)