### PR TITLE
fix(docz): non latin menu headings

### DIFF
--- a/core/docz-theme-default/src/components/shared/Sidebar/SmallLink.tsx
+++ b/core/docz-theme-default/src/components/shared/Sidebar/SmallLink.tsx
@@ -64,7 +64,8 @@ export const SmallLink: SFC<SmallLinkProps> = ({
   const [isActive, setActive] = useState(false)
 
   useEffect(() => {
-    const currentHash = location.hash && location.hash.slice(1, Infinity)
+    const decodedHash = decodeURI(location.hash)
+    const currentHash = decodedHash && decodedHash.slice(1, Infinity)
     setActive(Boolean(slug === currentHash))
   }, [location])
 

--- a/core/docz/src/components/Routes.tsx
+++ b/core/docz/src/components/Routes.tsx
@@ -20,7 +20,8 @@ export interface RoutesProps {
 const goToHash = ({ location }: HistoryListenerParameter) => {
   setTimeout(() => {
     if (location && location.hash) {
-      const id: string = location.hash.substring(1)
+      const decodedHash = decodeURI(location.hash)
+      const id: string = decodedHash.substring(1)
       const el: HTMLElement | null = document.getElementById(id)
       if (el) el.scrollIntoView()
     }


### PR DESCRIPTION
### Description
non-Latin menus are not activated and do not go to the corresponding sections.

### Screenshots

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/1243837/56864685-df359e00-69de-11e9-8657-b2c74458e7fa.png)| ![image](https://user-images.githubusercontent.com/1243837/56864758-93cfbf80-69df-11e9-8dbd-2fc0f21f44e7.png)|