### PR TITLE
feat(docz-core): extended path configuration for docgen

### DIFF
--- a/core/docz-core/src/config/argv.ts
+++ b/core/docz-core/src/config/argv.ts
@@ -26,7 +26,8 @@ export type ThemeConfig = Record<string, any>
 export interface DocgenConfig {
   handlers?: any[]
   resolver?: (ast: any, recast: any) => any
-  propFilter?: (prop: any) => boolean
+  propFilter?: (prop: any) => boolean,
+  searchPath: string
 }
 
 export interface Menu {

--- a/core/docz-core/src/states/props.ts
+++ b/core/docz-core/src/states/props.ts
@@ -9,8 +9,8 @@ import { Config } from '../config/argv'
 import { docgen } from '../utils/docgen'
 
 const getPattern = (config: Config) => {
-  const { typescript: ts, ignore, src: source } = config
-  const src = relative(paths.root, source)
+  const { typescript: ts, ignore, src: source, docgenConfig: docgenConfig } = config
+  const src = relative(paths.root, docgenConfig.searchPath ? docgenConfig.searchPath : source)
   return ignore
     .map(entry => `!**/${entry}`)
     .concat([

--- a/core/docz/src/components/Props.tsx
+++ b/core/docz/src/components/Props.tsx
@@ -112,7 +112,7 @@ export const Props: SFC<PropsProps> = ({
   const found =
     stateProps &&
     stateProps.length > 0 &&
-    stateProps.find(item => item.key === filename)
+    stateProps.find(item => filename ? item.key === filename : item.key.includes(`${componentName}.`))
 
   const value = get('value', found) || []
   const firstDefinition = first(value)


### PR DESCRIPTION
### Description
#827 
Support for typescript libraries with declarations (d.ts) included as npm-package in node_modules.