### PR TITLE
feat(docz-core): add config not use specifiers

### DIFF
--- a/core/docz-core/src/config/argv.ts
+++ b/core/docz-core/src/config/argv.ts
@@ -75,6 +75,7 @@ export interface Argv {
   native: boolean
   codeSandbox: boolean
   sourcemaps: boolean
+  notUseSpecifiers: boolean
   /* template args */
   title: string
   description: string

--- a/core/docz-core/src/config/babel.ts
+++ b/core/docz-core/src/config/babel.ts
@@ -31,7 +31,12 @@ export const getBabelConfig = async (
   ]
 
   const defaultPlugins = [
-    require.resolve('babel-plugin-export-metadata'),
+    [
+      require.resolve('babel-plugin-export-metadata'),
+      {
+        notUseSpecifiers: args.notUseSpecifiers,
+      },
+    ],
     [
       require.resolve('babel-plugin-named-asset-import'),
       {

--- a/other-packages/babel-plugin-export-metadata/src/index.js
+++ b/other-packages/babel-plugin-export-metadata/src/index.js
@@ -88,7 +88,7 @@ const insertNodeExport = t => (path, state) => {
       const declarationName = get(declaration, 'id.name')
       addFileMetaProperties(t, path, filename, declarationName)
     }
-  } else if (specifiers) {
+  } else if (specifiers && !state.opts.notUseSpecifiers) {
     for (specifier of specifiers) {
       const localName = get(specifier, 'local.name')
       const exportedName = get(specifier, 'exported.name')


### PR DESCRIPTION
### Description

#777 
For re-exported components cross index file, add config `notUseSpecifiers`, which allows to add the original component file name to the metadata.

| Before | After |
| ------ | ----- |
|![image](https://user-images.githubusercontent.com/1243837/57067925-c0d6e780-6ce9-11e9-8fc1-c99878c6271c.png)|![image](https://user-images.githubusercontent.com/1243837/57068016-f8de2a80-6ce9-11e9-821a-8e474bb8eee3.png)|