### PR TITLE
chore: remove private from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-  "private": true,
   "license": "MIT",
   "author": {
     "name": "Pedro Nauck",


### PR DESCRIPTION
### Description

This was preventing NPM from fetching data of the repository, homepage and issues to link them on the npmjs.com/package/docz page.
