### PR TITLE
fix(docz-theme-default): allow use of link component in ssr

### DIFF
--- a/core/docz-theme-default/src/components/ui/Link.tsx
+++ b/core/docz-theme-default/src/components/ui/Link.tsx
@@ -24,18 +24,21 @@ type LinkProps = React.AnchorHTMLAttributes<any>
 export const Link: SFC<LinkProps> = ({ href, ...props }) => {
   const { separator, linkComponent: Link } = useConfig()
   const docs = useDocs()
-  const toCheck = useMemo(
-    () =>
-      [
-        location.pathname
-          .split(separator)
-          .slice(0, -1)
-          .join(separator)
-          .slice(1),
-        (href || '').replace(/^(?:\.\/)+/gi, ''),
-      ].join('/'),
-    [separator]
-  )
+  const toCheck =
+    typeof window === 'undefined'
+      ? null
+      : useMemo(
+          () =>
+            [
+              location.pathname
+                .split(separator)
+                .slice(0, -1)
+                .join(separator)
+                .slice(1),
+              (href || '').replace(/^(?:\.\/)+/gi, ''),
+            ].join('/'),
+          [separator]
+        )
 
   const matched = docs && docs.find(doc => doc.filepath === toCheck)
   const nHref = matched ? matched.route : href


### PR DESCRIPTION
check environment before using global `location` variable in link component

fixes #832

### Description

Allows `gatsby build` to successfully run when using anchor tags.