### PR TITLE
Feat/opt out format files

### DIFF
--- a/core/docz-core/src/bundler/loaders.ts
+++ b/core/docz-core/src/bundler/loaders.ts
@@ -91,7 +91,7 @@ export const ts = (config: Config, args: Args, babelrc: BabelRC) => {
 }
 
 export const mdx = (config: Config, args: Args, babelrc: BabelRC) => {
-  const { mdPlugins, hastPlugins } = args
+  const { mdPlugins, hastPlugins, formatFiles, codeSandbox } = args
   const srcPath = path.resolve(paths.root, args.src)
   const rule = config.module
     .rule('mdx')
@@ -112,7 +112,7 @@ export const mdx = (config: Config, args: Args, babelrc: BabelRC) => {
         remarkDocz,
       ]),
       rehypePlugins: hastPlugins.concat([
-        [rehypeDocz, { root: paths.root, useCodeSandbox: args.codeSandbox }],
+        [rehypeDocz, { root: paths.root, codeSandbox, formatFiles }],
         slug,
       ]),
     })

--- a/core/docz-core/src/commands/build.ts
+++ b/core/docz-core/src/commands/build.ts
@@ -24,7 +24,7 @@ export const build = async (args: Arguments<any>) => {
 
   try {
     await Entries.writeApp(config, false)
-    await Entries.writeImports(await entries.get())
+    await Entries.writeImports(await entries.get(), config)
     await dataServer.start()
     await run('onPreBuild', config)
     await bundler.build(bundlerConfig)

--- a/core/docz-core/src/commands/dev.ts
+++ b/core/docz-core/src/commands/dev.ts
@@ -25,7 +25,7 @@ export const dev = async (args: Arguments<any>) => {
 
   try {
     await Entries.writeApp(config, true)
-    await Entries.writeImports(await entries.get())
+    await Entries.writeImports(await entries.get(), config)
   } catch (err) {
     logger.fatal('Failed to build your files')
     logger.error(err)

--- a/core/docz-core/src/config/argv.ts
+++ b/core/docz-core/src/config/argv.ts
@@ -57,6 +57,7 @@ export interface Argv {
   base: string
   src: string
   files: string | string[]
+  formatFiles: boolean
   ignore: string[]
   watchIgnore: string
   public: string
@@ -117,6 +118,10 @@ export const setArgs = (yargs: Yargs) => {
     .option('files', {
       type: 'string',
       default: getEnv('docz.files', '**/*.{md,markdown,mdx}'),
+    })
+    .option('formatFiles', {
+      type: 'boolean',
+      default: getEnv('docz.formatFiles', true),
     })
     .option('ignore', {
       type: 'array',

--- a/core/docz-core/src/lib/Entries.ts
+++ b/core/docz-core/src/lib/Entries.ts
@@ -26,7 +26,7 @@ const matchFilesWithSrc = (config: Config) => (files: string[]) => {
 }
 
 const writeAppFiles = async (config: Config, dev: boolean): Promise<void> => {
-  const { plugins, theme } = config
+  const { plugins, theme, formatFiles } = config
   const props = Plugin.propsOfPlugins(plugins)
 
   const onPreRenders = props('onPreRender')
@@ -52,8 +52,8 @@ const writeAppFiles = async (config: Config, dev: boolean): Promise<void> => {
 
   await fs.remove(paths.rootJs)
   await fs.remove(paths.indexJs)
-  await touch(paths.rootJs, rawRootJs)
-  await touch(paths.indexJs, rawIndexJs)
+  await touch(paths.rootJs, rawRootJs, formatFiles)
+  await touch(paths.indexJs, rawIndexJs, formatFiles)
 }
 
 export type EntryMap = Record<string, EntryObj>
@@ -64,10 +64,17 @@ export class Entries {
     await writeAppFiles(config, dev)
   }
 
-  public static async writeImports(map: EntryMap): Promise<void> {
+  public static async writeImports(
+    map: EntryMap,
+    config: Config
+  ): Promise<void> {
     const imports = await compiled(fromTemplates('imports.tpl.js'))
     const rawImportsJs = imports({ entries: Object.values(map) })
-    await touch(path.join(paths.app, 'imports.js'), rawImportsJs)
+    await touch(
+      path.join(paths.app, 'imports.js'),
+      rawImportsJs,
+      config.formatFiles
+    )
   }
 
   public all: Map<string, EntryObj>

--- a/core/docz-core/src/states/entries.ts
+++ b/core/docz-core/src/states/entries.ts
@@ -13,12 +13,14 @@ const mapToArray = (map: any = []) =>
     .map(entry => entry && { key: entry[0], value: entry[1] })
     .filter(Boolean)
 
-const updateEntries = (entries: Entries) => async (p: Params) => {
+const updateEntries = (entries: Entries, config: Config) => async (
+  p: Params
+) => {
   const prev = get('entries', p.getState())
   const map = await entries.get()
 
   if (map && !equal(prev, map)) {
-    await Entries.writeImports(map)
+    await Entries.writeImports(map, config)
     p.setState('entries', mapToArray(map))
   }
 }
@@ -45,7 +47,7 @@ export const state = (
   return {
     id: 'entries',
     start: async params => {
-      const update = updateEntries(entries)
+      const update = updateEntries(entries, config)
       await update(params)
 
       if (dev) {

--- a/core/docz-rollup/src/index.js
+++ b/core/docz-rollup/src/index.js
@@ -27,7 +27,7 @@ const defaultExternal = id =>
   !id.startsWith('\0') &&
   !id.startsWith('~') &&
   !id.startsWith('.') &&
-  !id.startsWith('/')
+  !id.startsWith(process.platform === 'win32' ? process.cwd() : '/')
 
 const createOutput = (dir = 'dist', defaultOpts) => {
   const opts = omitOpts(defaultOpts)

--- a/core/docz-utils/src/format.ts
+++ b/core/docz-utils/src/format.ts
@@ -9,10 +9,10 @@ export const formatter = (code: string) =>
     trailingComma: 'all',
   } as any)
 
-export const format = (code: string): Promise<string> =>
+export const format = (code: string, formatFiles: boolean): Promise<string> =>
   new Promise((resolve, reject) => {
     try {
-      const result = formatter(code)
+      const result = formatFiles ? formatter(code) : code
 
       resolve(result)
     } catch (err) {

--- a/core/docz-utils/src/fs.ts
+++ b/core/docz-utils/src/fs.ts
@@ -4,9 +4,11 @@ import { compile } from 'art-template'
 
 import { format } from './format'
 
-export const touch = (file: string, raw: string) =>
+export const touch = (file: string, raw: string, formatFiles: boolean) =>
   new Promise(async (resolve, reject) => {
-    const content = /jsx?$/.test(path.extname(file)) ? await format(raw) : raw
+    const content = /jsx?$/.test(path.extname(file))
+      ? await format(raw, formatFiles)
+      : raw
     const stream = fs.createWriteStream(file)
 
     stream.write(content, 'utf-8')

--- a/core/rehype-docz/src/index.ts
+++ b/core/rehype-docz/src/index.ts
@@ -13,13 +13,14 @@ const addComponentsProps = (
   scopes: string[],
   imports: string[],
   cwd: string,
-  useCodeSandbox: boolean
+  useCodeSandbox: boolean,
+  formatFiles: boolean
 ) => async (node: any, idx: number) => {
   const name = componentName(node.value)
   const tagOpen = new RegExp(`^\\<${name}`)
 
   if (isPlayground(name)) {
-    const formatted = await format(nodeToString(node))
+    const formatted = await format(nodeToString(node), formatFiles)
     const code = formatted.slice(1, Infinity)
     const scope = `{props: this ? this.props : props,${scopes.join(',')}}`
     const child = sanitizeCode(removeTags(code))
@@ -42,11 +43,12 @@ const addComponentsProps = (
 
 export interface PluginOpts {
   root: string
-  useCodeSandbox: boolean
+  codeSandbox: boolean
+  formatFiles: boolean
 }
 
 export default (opts: PluginOpts) => (tree: any, fileInfo: any) => {
-  const { root, useCodeSandbox } = opts
+  const { root, codeSandbox, formatFiles } = opts
   const importNodes = tree.children.filter((node: any) => is('import', node))
   const imports: string[] = flatten(importNodes.map(getFullImports))
   const scopes: string[] = flatten(importNodes.map(getImportsVariables))
@@ -55,7 +57,7 @@ export default (opts: PluginOpts) => (tree: any, fileInfo: any) => {
 
   const nodes = tree.children
     .filter((node: any) => is('jsx', node))
-    .map(addComponentsProps(scopes, imports, fileCwd, useCodeSandbox))
+    .map(addComponentsProps(scopes, imports, fileCwd, codeSandbox, formatFiles))
 
   return Promise.all(nodes).then(() => tree)
 }


### PR DESCRIPTION
### Description

This PR addresses two issues:

1. Fixing developing on Windows (again) known under and prev fixed by #783 #812 #821 #830 CC: @ejuo 
2. Adding a configuration option to opt out of Prettier formatting.
This is useful for repo's that already do their own formatting (such as ours) and adds a feature to satisfy #813 and #865 CC: @sw-yx 

### Review

- [ ] Check the copy
- [ ] ...
- [ ] ...

### Pre-merge checklist

- [ ] ...
- [ ] ...

### Screenshots

| Before | After |
| ------ | ----- |
| Image
![image](https://user-images.githubusercontent.com/16444755/57652928-fd9bbc00-75d0-11e9-865c-3bd606b27612.png)  | ![image](https://user-images.githubusercontent.com/16444755/57652950-068c8d80-75d1-11e9-9c31-5a347b7a5149.png) |