### PR TITLE
fix(gatsby-theme-docz): Use correct way to find layout entry.

### DIFF
--- a/core/gatsby-theme-docz/templates/Layout.tpl.js
+++ b/core/gatsby-theme-docz/templates/Layout.tpl.js
@@ -46,7 +46,7 @@ const Layout = ({ children, ...defaultProps }) => {
   const { pageContext: ctx } = defaultProps
   const data = useStaticQuery(query)
   const db = parseDatabase(data)
-  const entry = db.entries && db.entries.find(entry => entry.filepath === ctx.filepath)
+  const entry = db.entries && db.entries.find(entry => entry.value.filepath === ctx.entry.filepath)
 
   return (
     <Fragment>


### PR DESCRIPTION
The data structures of `db.entries` and `pageContext` which are from `graphql` are   `{key: "...", value: "..."}` So the `filepath` property should host on  `value` property.  
i.e  `db,entry`'s data structure should be like this:
``` 
"{"key":"docs/index.mdx","value":{"name":"Hello world","route":"/test/q","id":"73498ad0e1e62a714b08085d318f9de1","filepath":"docs/index.mdx","link":"https://github.com/YvesCoding/magic-scroll\\edit\\master\\docs/index.mdx","slug":"docs-index","menu":"","headings":[{"slug":"hello-world","depth":1,"value":"Hello world"}]}}"
```

### Description

Add here a description about your Pull Request

### Review

- [ ] Check the copy
- [ ] ...
- [ ] ...

### Pre-merge checklist

- [ ] ...
- [ ] ...

### Screenshots

| Before | After |
| ------ | ----- |
| Image  | Image |