### PR TITLE
Use clientLogLevel:silent in webpack-dev-server config

### DIFF
--- a/core/docz-core/src/bundler/devserver.ts
+++ b/core/docz-core/src/bundler/devserver.ts
@@ -17,7 +17,7 @@ export const devServerConfig = (hooks: ServerHooks, args: Args) => {
     publicPath: '/',
     compress: true,
     logLevel: args.debug ? 'debug' : 'silent',
-    clientLogLevel: args.debug ? 'info' : 'none',
+    clientLogLevel: args.debug ? 'info' : 'silent',
     contentBase: [nonExistentDir],
     watchContentBase: true,
     hot: true,


### PR DESCRIPTION
As of [v3.4.0](https://github.com/webpack/webpack-dev-server/releases/tag/v3.4.0) the option "none" is no longer a valid value for webpack-dev-server's clientLogLevel config.

https://github.com/webpack/webpack-dev-server/pull/1825
