### PR TITLE
fix(docz-theme-default): ensures the overlay is hidden when the sidebar is collapsed

### DIFF
--- a/core/docz-core/src/bundler/devserver.ts
+++ b/core/docz-core/src/bundler/devserver.ts
@@ -17,7 +17,7 @@ export const devServerConfig = (hooks: ServerHooks, args: Args) => {
     publicPath: '/',
     compress: true,
     logLevel: args.debug ? 'debug' : 'silent',
-    clientLogLevel: args.debug ? 'info' : 'none',
+    clientLogLevel: args.debug ? 'info' : 'silent',
     contentBase: [nonExistentDir],
     watchContentBase: true,
     hot: true,

--- a/core/docz-theme-default/src/components/shared/Sidebar/index.tsx
+++ b/core/docz-theme-default/src/components/shared/Sidebar/index.tsx
@@ -124,6 +124,7 @@ export const Sidebar: SFC = () => {
   const prevIsDesktop = usePrevious(isDesktop)
 
   useEffect(() => {
+    if (hidden) document.documentElement!.classList.remove('with-overlay')
     if (!hidden && !prevIsDesktop && isDesktop) {
       setHidden(true)
       document.documentElement!.classList.remove('with-overlay')


### PR DESCRIPTION
### Description

Closes issue #850. This bug was also seen in earlier issues (#476, #293). 

Perhaps if we merge this pull request then we can have the confidence that the overlay will always be removed when the sidebar is hidden.