### PR TITLE
Ensure Required only shows up when required

### DIFF
--- a/core/docz-core/src/bundler/devserver.ts
+++ b/core/docz-core/src/bundler/devserver.ts
@@ -17,7 +17,7 @@ export const devServerConfig = (hooks: ServerHooks, args: Args) => {
     publicPath: '/',
     compress: true,
     logLevel: args.debug ? 'debug' : 'silent',
-    clientLogLevel: args.debug ? 'info' : 'none',
+    clientLogLevel: args.debug ? 'info' : 'silent',
     contentBase: [nonExistentDir],
     watchContentBase: true,
     hot: true,

--- a/core/docz-core/src/bundler/devserver.ts
+++ b/core/docz-core/src/bundler/devserver.ts
@@ -17,7 +17,7 @@ export const devServerConfig = (hooks: ServerHooks, args: Args) => {
     publicPath: '/',
     compress: true,
     logLevel: args.debug ? 'debug' : 'silent',
-    clientLogLevel: args.debug ? 'info' : 'silent',
+    clientLogLevel: args.debug ? 'info' : 'none',
     contentBase: [nonExistentDir],
     watchContentBase: true,
     hot: true,

--- a/core/docz-theme-default/src/components/ui/Props/PropsTable.tsx
+++ b/core/docz-theme-default/src/components/ui/Props/PropsTable.tsx
@@ -123,7 +123,7 @@ export const PropsTable: React.SFC<PropsComponentProps> = ({
                     )}
                   </PropDefaultValue>
                 )}
-                {prop.required && (
+                {prop.required && !prop.defaultValue && (
                   <PropRequired>
                     <strong>required</strong>
                   </PropRequired>


### PR DESCRIPTION
### Description

In typescript props can be both required and have a default value. This ends up looking like `required` and `default=` are stacked next to of each other. Instead, if the value is required _and_ there is a default value, don't show the prop!

#### For instance

```tsx
interface Props {
  isClickable: boolean
}
class MyComponent extends Component<Props> {
  static defaultProps = {isClickable: true};

  render() { return null }
}

ReactDOM.render(<MyComponent />) // no error! 
```

In this case the prop is listed as required in the interface, but it isn't required _in usage_ because internal to the react component it knows the value is going to exist! 

### Review

- [ ] Is this how we should handle this behavior?

### Screenshots

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/1026035/58131708-3a207680-7bd4-11e9-9664-b6df03baf508.png) | ![image](https://user-images.githubusercontent.com/1026035/58131735-47d5fc00-7bd4-11e9-9c9b-c3539e96f08e.png) |