### PR TITLE
fix(docz-core): fix `open` argument for `dev` command

### DIFF
--- a/core/docz-core/src/bundler/devserver.ts
+++ b/core/docz-core/src/bundler/devserver.ts
@@ -22,7 +22,7 @@ export const devServerConfig = (hooks: ServerHooks, args: Args) => {
     watchContentBase: true,
     hot: true,
     quiet: !args.debug,
-    open: true,
+    open: false,
     watchOptions: {
       ignored: ignoredFiles(srcPath),
     },


### PR DESCRIPTION
### Description

This change change the default value of argument `open` for the command `dev` to match the declared option in `core/docz-core/src/config/argv.ts`

```js
.option('open', {
  alias: 'o',
  describe: 'auto open browser in dev mode',
  type: 'boolean',
  default: false,
})
```

The issue was that `docz dev` was opening the browser even with the option `--no-open`.