### PR TITLE
Set devServerConfig to respect args.open

### DIFF
--- a/core/docz-core/src/bundler/devserver.ts
+++ b/core/docz-core/src/bundler/devserver.ts
@@ -22,7 +22,7 @@ export const devServerConfig = (hooks: ServerHooks, args: Args) => {
     watchContentBase: true,
     hot: true,
     quiet: !args.debug,
-    open: true,
+    open: !!args.open,
     watchOptions: {
       ignored: ignoredFiles(srcPath),
     },


### PR DESCRIPTION
### Description

This commit makes the`--open` flag work as it should. Without this patch, the browser always opens automatically
