### PR TITLE
fix(remark-docz): fix alias in the src of a mdx's image

### DIFF
--- a/core/docz-core/src/bundler/devserver.ts
+++ b/core/docz-core/src/bundler/devserver.ts
@@ -17,7 +17,7 @@ export const devServerConfig = (hooks: ServerHooks, args: Args) => {
     publicPath: '/',
     compress: true,
     logLevel: args.debug ? 'debug' : 'silent',
-    clientLogLevel: args.debug ? 'info' : 'none',
+    clientLogLevel: args.debug ? 'info' : 'silent',
     contentBase: [nonExistentDir],
     watchContentBase: true,
     hot: true,

--- a/core/remark-docz/src/index.ts
+++ b/core/remark-docz/src/index.ts
@@ -77,7 +77,7 @@ const createImgSrc = (src: string) => {
   }
 
   let { pathname } = parsed as { pathname: string }
-  if (!/^\.[./]+/.test(pathname)) {
+  if (!/^(?:\.[./]+|@)/.test(pathname)) {
     pathname = `./${pathname}`
   }
   return t.jsxExpressionContainer(


### PR DESCRIPTION
### Description

This changes is fixing the following issue:

If I use the config:
```
onCreateWebpackChain: config => {
    config.resolve.alias.set('@images', `${PUBLIC}/images`)
    return config
}
```

and a MDX page like:
```
![foobar](@images/foobar.png)
```

I get the error:
```
Module not found: Error: Can't resolve './@images/foobar.png' in '...'
```