### PR TITLE
fix(docz): component Props false positives when looking in state

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,5 @@
+# These are supported funding model platforms
+
+github: [pedronauck]
+patreon: pedronauck
+open_collective: pedronauck

--- a/core/docz-core/src/bundler/devserver.ts
+++ b/core/docz-core/src/bundler/devserver.ts
@@ -17,7 +17,7 @@ export const devServerConfig = (hooks: ServerHooks, args: Args) => {
     publicPath: '/',
     compress: true,
     logLevel: args.debug ? 'debug' : 'silent',
-    clientLogLevel: args.debug ? 'info' : 'none',
+    clientLogLevel: args.debug ? 'info' : 'silent',
     contentBase: [nonExistentDir],
     watchContentBase: true,
     hot: true,

--- a/core/docz/src/components/Props.tsx
+++ b/core/docz/src/components/Props.tsx
@@ -114,7 +114,7 @@ export const Props: SFC<PropsProps> = ({
     stateProps &&
     stateProps.length > 0 &&
     stateProps.find(item =>
-      filename ? item.key === filename : item.key.includes(`${componentName}.`)
+      filename ? item.key === filename : item.key.includes(`/${componentName}.`)
     )
 
   const value = get('value', found) || []


### PR DESCRIPTION
### Description

When rendering `Props` we've found that the component can match the wrong file. E.g. rendering the Props from `elements/Button.jsx` might accidentally show the props for `elements/SubmitButton.jsx` as the match is only done on `${componentName}.`.

Propose including a leading slash at the start, which should ensure this can't happen.