### PR TITLE
Update dependencies (react-live@2.1.2)

### DIFF
--- a/core/docz-theme-default/package.json
+++ b/core/docz-theme-default/package.json
@@ -35,7 +35,7 @@
     "react-codemirror2": "^6.0.0",
     "react-dom": "^16.8.6",
     "react-feather": "^1.1.6",
-    "react-live": "2.0.1",
+    "react-live": "2.1.2",
     "react-perfect-scrollbar": "^1.5.0",
     "styled-components": "^4.2.0",
     "typescript": "3.3.4000"


### PR DESCRIPTION
The existing react-live version has a dependency on a library that is not MIT.

### Description

More details on the react-live PR: https://github.com/FormidableLabs/react-live/pull/147