### PR TITLE
Allow to override the playground's editor's code

### DIFF
--- a/core/docz-theme-default/src/components/ui/Playground/index.tsx
+++ b/core/docz-theme-default/src/components/ui/Playground/index.tsx
@@ -109,6 +109,7 @@ export const Playground: SFC<PlaygroundProps> = ({
   style,
   scope,
   wrapper: CustomWrapper = Fragment,
+  editorCode,
 }) => {
   const { themeConfig, native } = useConfig()
   const initialShowEditor = getter(themeConfig, 'showPlaygroundEditor')
@@ -124,6 +125,7 @@ export const Playground: SFC<PlaygroundProps> = ({
   const [width, setWidth] = useState(() => initialWidth)
   const [height, setHeight] = useState(() => initialHeight)
   const [showEditor, setShowEditor] = useState(() => Boolean(initialShowEditor))
+  const editorCodeIsOverriden = !!editorCode
 
   const state = {
     fullscreen,
@@ -268,15 +270,15 @@ export const Playground: SFC<PlaygroundProps> = ({
               <StyledError />
             </PreviewWrapper>
             <ActionsBar
-              {...{ fullscreen, showEditor, code }}
+              {...{ fullscreen, showEditor, code: editorCodeIsOverriden ? editorCode as string : code }}
               codesandboxUrl={codesandboxUrl(native)}
               onClickRefresh={handleRefresh}
               onClickEditor={handleToggleShowEditor}
               onClickFullscreen={handleToggleFullscreen}
             />
             {showEditor && (
-              <Pre {...editorProps} onChange={setCode} readOnly={false}>
-                {code}
+              <Pre {...editorProps} onChange={setCode} readOnly={editorCodeIsOverriden}>
+                {editorCodeIsOverriden ? editorCode as string : code}
               </Pre>
             )}
           </Wrapper>

--- a/core/docz/src/components/Playground.tsx
+++ b/core/docz/src/components/Playground.tsx
@@ -8,6 +8,7 @@ export interface PlaygroundProps {
   style?: any
   wrapper?: ComponentType<any>
   children: any
+  editorCode?: string
   __scope: Record<string, any>
   __position: number
   __code: string
@@ -19,6 +20,7 @@ const Playground: SFC<PlaygroundProps> = ({
   style,
   wrapper: Wrapper,
   children,
+  editorCode,
   __scope,
   __position,
   __code,
@@ -26,7 +28,7 @@ const Playground: SFC<PlaygroundProps> = ({
 }) => {
   const components = useComponents()
   if (!components || !components.playground) return null
-  const props = { className, style, components }
+  const props = { className, style, components, editorCode }
 
   return (
     <components.playground

--- a/core/docz/src/hooks/useComponents.tsx
+++ b/core/docz/src/hooks/useComponents.tsx
@@ -19,6 +19,7 @@ export interface PlaygroundProps {
   code: string
   codesandbox: string
   scope: Record<string, any>
+  editorCode?: string
 }
 
 export type PlaygroundComponent = CT<PlaygroundProps>


### PR DESCRIPTION
### Description

Currently the code that gets displayed in the playground's editor is the same as the one passed to the playground as its children. But because of issue #904, I had to be able to pass a simple component to the playground, while still showing the actual code of that component in the playground's editor.

This PR allows to pass an additional prop to the `Playground` component, called `editorCode`, which is the actual code (as a string) that will be shown in the editor, regardless of the code passed to the playground as its children.

For example :

- This caused issues :
```
<Playground>
  {() => {
    type Name = string;

    interface Person {
      name: Name;
    }

    const person: Person = {
      name: "John Doe"
    };

    return <div>{person.name}</div>
  }}
</Playground>
```
- This didn't :
```
// Examples.tsx
type Name = string;

interface Person {
  name: Name;
}

const person: Person = {
  name: "John Doe"
};

export const Example = () => <div>{person.name}</div>
```
```
import { Example } from "./Examples.tsx"

<Playground>
  <Example />
</Playground>
```
But doing so makes the playground's editor only show `<Example />`, which forces the user to open the `Examples.tsx` file to actually see the code used.

With this PR, I can do the following and have the expected result :
```
import { Example } from "./Examples.tsx"
const exampleCode =  "<The example's code (the actual way to get it can vary and is beyond the scope of this PR).>"

<Playground editorCode={exampleCode}>
  <Example />
</Playground>
```

Edit : This PR revealed an expected but undesirable effect of the playground for my use cases, which I described and fixed in #907.