### PR TITLE
Allow to hide the LiveError overlay

### DIFF
--- a/core/docz-theme-default/README.md
+++ b/core/docz-theme-default/README.md
@@ -71,6 +71,10 @@ const config = {
    */
   showPlaygroundEditor: true,
   /**
+   * Show/hide the LiveError overlay when errors are detected 
+   */
+  showLiveError: true,
+  /**
    * Set the numbers of max lines before scroll editor
    */
   linesToScrollEditor: 14

--- a/core/docz-theme-default/src/components/ui/Playground/index.tsx
+++ b/core/docz-theme-default/src/components/ui/Playground/index.tsx
@@ -124,6 +124,7 @@ export const Playground: SFC<PlaygroundProps> = ({
   const [width, setWidth] = useState(() => initialWidth)
   const [height, setHeight] = useState(() => initialHeight)
   const [showEditor, setShowEditor] = useState(() => Boolean(initialShowEditor))
+  const showErrors = getter(themeConfig, 'showLiveError')
 
   const state = {
     fullscreen,
@@ -265,7 +266,7 @@ export const Playground: SFC<PlaygroundProps> = ({
                   <LivePreview className={className} style={style} />
                 </CustomWrapper>
               </StyledPreviewWrapper>
-              <StyledError />
+              {showErrors && <StyledError />}
             </PreviewWrapper>
             <ActionsBar
               {...{ fullscreen, showEditor, code }}

--- a/core/docz-theme-default/src/config.ts
+++ b/core/docz-theme-default/src/config.ts
@@ -9,5 +9,6 @@ export const config = {
   radii: '2px',
   mode: 'light',
   showPlaygroundEditor: false,
+  showLiveError: true,
   linesToScrollEditor: 18,
 }


### PR DESCRIPTION
### Description

Currently the playground's component preview **always** shows errors detected in the editor. But because of issue #904, I had to do PR #906. And because of that, the code in the editor, while perfectly valid, might be judged invalid by the playground, which will show the LiveError overlay on top of my perfectly rendered component.

This PR allows to configure the `docz-theme-default` to always hide the LiveError overlay, through a new `themeConfig` key called `showLiveError` (as boolean, default to true). For example :
```
// doczrc.js
export default {
  themeConfig: {
    showLiveError: false
  }
};
```

### To reproduce

Based on PR #906 :

- Example.tsx

```
import * as React from "react";

type Name = string;

interface Person {
  name: Name;
}

const person: Person = {
  name: "John Doe"
};

export const Example = () => <div>{person.name}</div>
```

- Example.mdx

```
---
name: Example
menu: Components
---

import { Playground, Props } from 'docz'
import { Example } from "./Example"
const exampleCode = `import * as React from "react";\n\ntype Name = string;\n\ninterface Person {\n  name: Name;\n}\n\nconst person: Person = {\n  name: "John Doe"\n};\n\nexport const Example = () => <div>{person.name}</div>\n`

# Example

<Playground editorCode={exampleCode}>
  <Example />
</Playground>
```

### Screenshots

| Before | After |
| ------ | ----- |
| ![before](https://user-images.githubusercontent.com/47041155/58761226-282ec400-8542-11e9-82a5-bffc4f1e2be6.png) | ![after](https://user-images.githubusercontent.com/47041155/58761229-2f55d200-8542-11e9-8615-5c54204afc04.png) |