### PR TITLE
fix(docz): preserve casing of named enum

### DIFF
--- a/core/docz/src/components/Props.tsx
+++ b/core/docz/src/components/Props.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { SFC, ComponentType } from 'react'
 import { first, get } from 'lodash/fp'
-import capitalize from 'capitalize'
 
 import { doczState } from '../state'
 import { useComponents } from '../hooks'
@@ -74,8 +73,10 @@ export const getPropType = (prop: Prop) => {
   const propName = get('name', prop.flowType || prop.type)
   if (!propName) return null
 
-  const isEnum = propName.startsWith('"') || propName === 'enum'
-  const name = capitalize(isEnum ? 'enum' : propName)
+  const isNamedEnum = propName.startsWith('"')
+  const isOpaqueEnum = propName === 'enum'
+  const isEnum = isNamedEnum || isOpaqueEnum
+  const name = isOpaqueEnum ? 'Enum' : propName
   const value = get('type.value', prop)
   if (!name) return null
 

--- a/examples/typescript/src/components/Alert.mdx
+++ b/examples/typescript/src/components/Alert.mdx
@@ -4,7 +4,7 @@ menu: Components
 ---
 
 import { Playground, Props } from 'docz'
-import { Alert } from './Alert'
+import { Alert, AlertKind } from './Alert'
 
 # Alert
 
@@ -21,10 +21,10 @@ import { Alert } from './Alert'
 ## Using different kinds
 
 <Playground>
-  <Alert kind="info">Some message</Alert>
-  <Alert kind="positive">Some message</Alert>
-  <Alert kind="negative">Some message</Alert>
-  <Alert kind="warning">Some message</Alert>
+  <Alert kind={AlertKind.Info}>Some message</Alert>
+  <Alert kind={AlertKind.Positive}>Some message</Alert>
+  <Alert kind={AlertKind.Negative}>Some message</Alert>
+  <Alert kind={AlertKind.Warning}>Some message</Alert>
 </Playground>
 
 ## Use with children as a function

--- a/examples/typescript/src/components/Alert.tsx
+++ b/examples/typescript/src/components/Alert.tsx
@@ -1,14 +1,20 @@
 import React, { SFC } from 'react'
 import styled from 'styled-components'
 
-export type Kind = 'info' | 'positive' | 'negative' | 'warning'
-export type KindMap = Record<Kind, string>
+export enum AlertKind {
+  Info = 'info',
+  Positive = 'positive',
+  Negative = 'negative',
+  Warning = 'warning',
+}
+
+export type KindMap = Record<AlertKind, string>
 
 const kinds: KindMap = {
-  info: '#5352ED',
-  positive: '#2ED573',
-  negative: '#FF4757',
-  warning: '#FFA502',
+  [AlertKind.Info]: '#5352ED',
+  [AlertKind.Positive]: '#2ED573',
+  [AlertKind.Negative]: '#FF4757',
+  [AlertKind.Warning]: '#FFA502',
 }
 
 export interface AlertProps {
@@ -16,7 +22,7 @@ export interface AlertProps {
    * Set this to change alert kind
    * @default info
    */
-  kind: 'info' | 'positive' | 'negative' | 'warning'
+  kind: AlertKind
 }
 
 const AlertStyled = styled('div')`
@@ -24,7 +30,7 @@ const AlertStyled = styled('div')`
   background: white;
   border-radius: 3px;
   color: white;
-  background: ${({ kind = 'info' }: AlertProps) => kinds[kind]};
+  background: ${({ kind = AlertKind.Info }: AlertProps) => kinds[kind]};
 `
 
 export const Alert: SFC<AlertProps> = ({ kind, ...props }) => (


### PR DESCRIPTION
### Description

This PR fixes an issue where named enums found in TypeScript components with enums for props were being rewritten in a way that changed their character casing.

### Screenshots

| Before | After |
| ------ | ----- |
| <img width="1529" alt="before" src="https://user-images.githubusercontent.com/678548/59601296-812e5880-90fb-11e9-88a2-c3f0eb5f38a8.png"> | <img width="1524" alt="after" src="https://user-images.githubusercontent.com/678548/59601261-6eb41f00-90fb-11e9-9d30-a4a28fa23831.png"> |