### PR TITLE
fix: add missing source sans pro font

### DIFF
--- a/core/gatsby-theme-docz/src/index.css
+++ b/core/gatsby-theme-docz/src/index.css
@@ -1,1 +1,2 @@
 @import url('https://fonts.googleapis.com/css?family=Inconsolata&display=swap');
+@import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap');


### PR DESCRIPTION
### Description

This PR fixes Source Sans Pro loading 

Closes #961 

### Screenshots

| Before | After |
| ------ | ----- |
|<img width="921" alt="Screenshot 2019-08-06 at 15 48 06" src="https://user-images.githubusercontent.com/1502981/62550215-c6e8e100-b861-11e9-8dc4-3cfe68c48397.png">|<img width="924" alt="Screenshot 2019-08-06 at 15 45 38" src="https://user-images.githubusercontent.com/1502981/62550232-cf411c00-b861-11e9-9100-1303a0f60a23.png">|