### PR TITLE
fix: replace fragment tag to the short syntax

### DIFF
--- a/core/gatsby-theme-docz/src/components/NavLink/index.js
+++ b/core/gatsby-theme-docz/src/components/NavLink/index.js
@@ -22,7 +22,7 @@ export const NavLink = ({ item, ...props }) => {
   const showHeadings = isCurrent && headings && headings.length > 0
 
   return (
-    <React.Fragment>
+    <>
       <Link {...props} to={to} sx={styles.link} activeClassName="active" />
       {showHeadings &&
         headings.map(heading => (
@@ -35,6 +35,6 @@ export const NavLink = ({ item, ...props }) => {
             {heading.value}
           </Link>
         ))}
-    </React.Fragment>
+    </>
   )
 }

--- a/core/gatsby-theme-docz/src/components/Sidebar/index.js
+++ b/core/gatsby-theme-docz/src/components/Sidebar/index.js
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import React, { Fragment, useState } from 'react'
+import React, { useState } from 'react'
 import { Global } from '@emotion/core'
 import { jsx, Box } from 'theme-ui'
 import { useMenus } from 'docz'
@@ -18,7 +18,7 @@ export const Sidebar = React.forwardRef((props, ref) => {
   }
 
   return (
-    <Fragment>
+    <>
       <Box onClick={props.onClick} sx={styles.overlay(props)}>
         {props.open && <Global styles={styles.global} />}
       </Box>
@@ -38,6 +38,6 @@ export const Sidebar = React.forwardRef((props, ref) => {
             )
           })}
       </Box>
-    </Fragment>
+    </>
   )
 })


### PR DESCRIPTION
### Description

Fix invalid prop `css` in console regarding Fragment attributes.

**The bug**:
In the explicit Fragment usage, `key` is the only attribute that can be passed and in this case, is receiving `css` property. 

**The fix**:
Replace explicit Fragment usage to shortcut syntax that's doesn’t support keys or attributes.

Closes #965 

### Screenshots

| Before | After |
| ------ | ----- |
|<img width="1920" alt="Screenshot 2019-08-06 at 18 17 40" src="https://user-images.githubusercontent.com/1502981/62561782-cb1ff900-b877-11e9-8bd6-1cafa5735a1d.png">|<img width="1022" alt="Screenshot 2019-08-06 at 18 13 44" src="https://user-images.githubusercontent.com/1502981/62561755-bc394680-b877-11e9-98a8-28cb6fcb318b.png">|