### PR TITLE
Basic example docs and temp fix. Add explicit dependency to scheduler in docz package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,17 +32,17 @@ This documentation is for Docz [v2](https://github.com/pedronauck/docz/pull/950)
 
 ## 🎩 &nbsp; Features
 
-- 🔩 **Powered by Gatsby.** Bundling and ecossystem powered by [Gatsby](https://gatsbyjs.org).
+- 🔩 **Powered by Gatsby.** Bundling and ecosystem powered by [Gatsby](https://gatsbyjs.org).
 - 🧘 **Zero config and easy.** Don't worry about complex configurations steps.
 - ⚡️ **Blazing Fast.** Full hot reload support with webpack 4 and automatic code splitting.
 - 💅 **Easy to customize.** Create and use real customizable themes.
 - 📝 **[MDX](https://github.com/mdx-js/mdx) Based.** Write markdown enhanced by the power of components.
-- 🎛 **Pluggable.** Use plugins to manipulate and customise Docz to suit your needs.
+- 🎛 **Pluggable.** Use plugins to manipulate and customize Docz to suit your needs.
 - 🔐 **Typescript Support.** Full support for TypeScript. Write your type definitions with no extra setup required.
 
 ## 🤔 &nbsp; Why?
 
-Libraries that make development easier are appearing every day. Styleguides and design systems are growing in popularity. Today, tools that allow us to get our best work done and be efficient are necessary. We shouldn't be spending too much time on tasks that should be trivial. This is why we created **Docz**.
+Libraries that make development easier are appearing every day. Style guides and design systems are growing in popularity. Today, tools that allow us to get our best work done and be efficient are necessary. We shouldn't be spending too much time on tasks that should be trivial. This is why we created **Docz**.
 
 Documenting code is one of the most important and time-heavy processes when you're creating something new. A lot of time is wasted on unnecessarily attempting to build a documentation site that will match the style we want.
 

--- a/core/docz/package.json
+++ b/core/docz/package.json
@@ -33,6 +33,7 @@
     "marksy": "^8.0.0",
     "match-sorter": "^3.1.1",
     "prop-types": "^15.7.2",
+    "scheduler": "^0.15.0",
     "ulid": "^2.3.0",
     "yargs": "^13.3.0"
   },

--- a/core/docz/src/components/Props.tsx
+++ b/core/docz/src/components/Props.tsx
@@ -117,7 +117,7 @@ export const Props: SFC<PropsProps> = ({
     stateProps &&
     stateProps.length > 0 &&
     stateProps.find(item =>
-      filename ? item.key === filename : item.key.includes(`/${componentName}.`)
+      item.key.includes(`/${componentName}.`) || item.key === filename 
     )
 
   const value = get('value', found) || []

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -1,0 +1,21 @@
+# Basic Docz example
+
+## Download manually
+
+```sh
+curl https://codeload.github.com/pedronauck/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/basic
+mv basic docz-basic-example
+cd docz-basic-example
+```
+
+## Setup
+
+```sh
+yarn # npm i
+```
+
+## Run
+
+```sh
+yarn dev # npm run dev
+```

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -17,8 +17,7 @@
     "@emotion/styled": "^10.0.14",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
-    "react-dom": "^16.8.6",
-    "scheduler": "^0.15.0"
+    "react-dom": "^16.8.6"
   },
   "devDependencies": {
     "docz": "^2.0.0-rc.1"

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -17,7 +17,8 @@
     "@emotion/styled": "^10.0.14",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
-    "react-dom": "^16.8.6"
+    "react-dom": "^16.8.6",
+    "scheduler": "^0.15.0"
   },
   "devDependencies": {
     "docz": "^2.0.0-rc.1"


### PR DESCRIPTION
### Description

When trying to run the basic example I was greeted with a `callback is not a function` React error. This is because Gatsby has an optionalDependency to Ink which explicitly asks for version 0.13.2 of the scheduler that doesn't have hook support.

I moved the scheduler dependency to the docz package and temporarily added it to the basic example

Also added copy paste-able instructions to setup the example

