### PR TITLE
Fix basic example and add docs. Add explicit dependency to scheduler in docz package.

### DIFF
--- a/core/docz/package.json
+++ b/core/docz/package.json
@@ -33,6 +33,7 @@
     "marksy": "^8.0.0",
     "match-sorter": "^3.1.1",
     "prop-types": "^15.7.2",
+    "scheduler": "^0.15.0",
     "ulid": "^2.3.0",
     "yargs": "^13.3.0"
   },

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -1,0 +1,21 @@
+# Basic Docz example
+
+## Download manually
+
+```sh
+curl https://codeload.github.com/pedronauck/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/basic
+mv basic docz-basic-example
+cd docz-basic-example
+```
+
+## Setup
+
+```sh
+yarn # npm i
+```
+
+## Run
+
+```sh
+yarn dev # npm run dev
+```

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -17,7 +17,8 @@
     "@emotion/styled": "^10.0.14",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
-    "react-dom": "^16.8.6"
+    "react-dom": "^16.8.6",
+    "scheduler": "^0.15.0"
   },
   "devDependencies": {
     "docz": "^2.0.0-rc.1"


### PR DESCRIPTION
### Description

When trying to run the basic example I was greeted with a `callback is not a function` React error. This is because Gatsby has an optionalDependency to Ink which explicitly asks for version 0.13.2 of the scheduler that doesn't have hook support.

I moved the scheduler dependency to the docz package and temporarily added it to the basic example

Also added copy paste-able instructions to setup the example

