### PR TITLE
fix(docz-example-typescript): add scheduler dep and docs #1020

### DIFF
--- a/examples/flow/README.md
+++ b/examples/flow/README.md
@@ -1,0 +1,21 @@
+# Flow Docz example
+
+## Download
+
+```sh
+curl https://codeload.github.com/pedronauck/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/flow
+mv flow docz-flow-example
+cd docz-flow-example
+```
+
+## Setup
+
+```sh
+yarn # npm i
+```
+
+## Run
+
+```sh
+yarn dev # npm run dev
+```

--- a/examples/flow/gatsby-node.js
+++ b/examples/flow/gatsby-node.js
@@ -1,0 +1,5 @@
+exports.onCreateBabelConfig = ({ actions }) => {
+  actions.setBabelPreset({
+    name: `@babel/preset-flow`,
+  })
+}

--- a/examples/flow/src/components/Alert.mdx
+++ b/examples/flow/src/components/Alert.mdx
@@ -3,8 +3,8 @@ name: Alert
 menu: Components
 ---
 
-import { Playground, Props } from 'docz'
-import { Alert } from './Alert'
+import { Playground, Props } from "docz";
+import { Alert } from "./Alert";
 
 # Alert
 
@@ -25,16 +25,4 @@ import { Alert } from './Alert'
   <Alert kind="positive">Some message</Alert>
   <Alert kind="negative">Some message</Alert>
   <Alert kind="warning">Some message</Alert>
-</Playground>
-
-## Use with children as a function
-
-<Playground>
-  {() => {
-    const message = 'Hello world'
-
-    return (
-      <Alert>{message}</Alert>
-    )
-  }}
 </Playground>

--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -1,0 +1,21 @@
+# Typescript Docz example
+
+## Download manually
+
+```sh
+curl https://codeload.github.com/pedronauck/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/typescript
+mv typescript docz-typescript-example
+cd docz-typescript-example
+```
+
+## Setup
+
+```sh
+yarn # npm i
+```
+
+## Run
+
+```sh
+yarn dev # npm run dev
+```

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -16,7 +16,8 @@
     "@emotion/core": "^10.0.14",
     "@emotion/styled": "^10.0.14",
     "react": "^16.8.6",
-    "react-dom": "^16.8.6"
+    "react-dom": "^16.8.6",
+    "scheduler": "^0.15.0"
   },
   "devDependencies": {
     "@types/react": "^16.8.23",


### PR DESCRIPTION
### Description

Add instruction to run TypeScript example.
Add scheduler dependency to typescript example while waiting for a release > rc.1