### PR TITLE
docs(docz-example-now): add deployment with now example

### DIFF
--- a/examples/now/.gitignore
+++ b/examples/now/.gitignore
@@ -1,0 +1,3 @@
+public
+node_modules
+.docz

--- a/examples/now/CHANGELOG.md
+++ b/examples/now/CHANGELOG.md
@@ -1,0 +1,906 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [2.0.0-rc.2](https://github.com/pedronauck/docz/compare/v2.0.0-rc.1...v2.0.0-rc.2) (2019-08-28)
+
+
+### Bug Fixes
+
+* **docz-example-basic:** add explicit dependency to scheduler ([a4c5f9c](https://github.com/pedronauck/docz/commit/a4c5f9c))
+
+
+
+
+
+# [2.0.0-rc.1](https://github.com/pedronauck/docz/compare/v1.2.0...v2.0.0-rc.1) (2019-07-18)
+
+
+### Bug Fixes
+
+* bump version ([a346b59](https://github.com/pedronauck/docz/commit/a346b59))
+
+
+### Features
+
+* add markdown parsing on props description ([1087539](https://github.com/pedronauck/docz/commit/1087539))
+* **gatsby-theme-docz:** improve code highlight ([d265444](https://github.com/pedronauck/docz/commit/d265444))
+* dynamic src and root path ([c071556](https://github.com/pedronauck/docz/commit/c071556))
+* **docz-core:** add build and serve command with gatsby ([e85c82b](https://github.com/pedronauck/docz/commit/e85c82b))
+* docz running using gatsby under the hood ([10ffd48](https://github.com/pedronauck/docz/commit/10ffd48))
+
+
+
+
+
+# [1.2.0](https://github.com/pedronauck/docz/compare/v1.1.0...v1.2.0) (2019-05-08)
+
+**Note:** Version bump only for package docz-example-basic
+
+
+
+
+
+# [1.1.0](https://github.com/pedronauck/docz/compare/v1.0.4...v1.1.0) (2019-05-01)
+
+**Note:** Version bump only for package docz-example-basic
+
+
+
+
+
+## [1.0.4](https://github.com/pedronauck/docz/compare/v1.0.3...v1.0.4) (2019-04-18)
+
+**Note:** Version bump only for package docz-example-basic
+
+
+
+
+
+## [1.0.3](https://github.com/pedronauck/docz/compare/v1.0.2...v1.0.3) (2019-04-15)
+
+**Note:** Version bump only for package docz-example-basic
+
+
+
+
+
+## [1.0.2](https://github.com/pedronauck/docz/compare/v1.0.1...v1.0.2) (2019-04-15)
+
+**Note:** Version bump only for package docz-example-basic
+
+
+
+
+
+## [1.0.1](https://github.com/pedronauck/docz/compare/v1.0.0...v1.0.1) (2019-04-14)
+
+**Note:** Version bump only for package docz-example-basic
+
+
+
+
+
+# [1.0.0](https://github.com/pedronauck/docz/compare/v1.0.0-rc.8...v1.0.0) (2019-04-11)
+
+**Note:** Version bump only for package docz-example-basic
+
+
+
+
+
+# [1.0.0-rc.4](https://github.com/pedronauck/docz/compare/v1.0.0-rc.3...v1.0.0-rc.4) (2019-03-29)
+
+
+### Bug Fixes
+
+* add missing dependency on examples ([af8ec2d](https://github.com/pedronauck/docz/commit/af8ec2d))
+
+
+
+
+
+# [1.0.0-rc.3](https://github.com/pedronauck/docz/compare/v1.0.0-rc.2...v1.0.0-rc.3) (2019-03-21)
+
+**Note:** Version bump only for package docz-example-basic
+
+
+
+
+
+# [1.0.0-beta.0](https://github.com/pedronauck/docz/compare/v1.0.0-alpha.1...v1.0.0-beta.0) (2019-03-19)
+
+**Note:** Version bump only for package docz-example-basic
+
+
+
+
+
+# [1.0.0-alpha.0](https://github.com/pedronauck/docz/compare/v0.13.5...v1.0.0-alpha.0) (2019-03-19)
+
+
+### Features
+
+* add initial gatsby integration ([#630](https://github.com/pedronauck/docz/issues/630)) ([70d40cc](https://github.com/pedronauck/docz/commit/70d40cc)), closes [#609](https://github.com/pedronauck/docz/issues/609)
+* add playground component ([cde6511](https://github.com/pedronauck/docz/commit/cde6511))
+* new Props component ([80451b1](https://github.com/pedronauck/docz/commit/80451b1))
+
+
+
+
+
+## [0.13.6](https://github.com/pedronauck/docz/compare/v0.13.5...v0.13.6) (2018-12-26)
+
+**Note:** Version bump only for package docz-example-basic
+
+
+
+
+
+## [0.13.5](https://github.com/pedronauck/docz/compare/v0.13.4...v0.13.5) (2018-12-19)
+
+**Note:** Version bump only for package docz-example-basic
+
+
+
+
+
+## [0.13.4](https://github.com/pedronauck/docz/compare/v0.13.3...v0.13.4) (2018-12-17)
+
+**Note:** Version bump only for package docz-example-basic
+
+
+
+
+
+## [0.13.3](https://github.com/pedronauck/docz/compare/v0.13.2...v0.13.3) (2018-12-17)
+
+**Note:** Version bump only for package docz-example-basic
+
+
+
+
+
+## [0.13.2](https://github.com/pedronauck/docz/compare/v0.13.1...v0.13.2) (2018-12-17)
+
+**Note:** Version bump only for package docz-example-basic
+
+
+
+
+
+## [0.13.1](https://github.com/pedronauck/docz/compare/v0.13.0...v0.13.1) (2018-12-17)
+
+**Note:** Version bump only for package docz-example-basic
+
+
+
+
+
+# [0.13.0](https://github.com/pedronauck/docz/compare/v0.12.17...v0.13.0) (2018-12-17)
+
+**Note:** Version bump only for package docz-example-basic
+
+
+
+
+
+## [0.12.17](https://github.com/pedronauck/docz/compare/v0.12.16...v0.12.17) (2018-12-14)
+
+**Note:** Version bump only for package docz-example-basic
+
+
+
+
+
+## [0.12.16](https://github.com/pedronauck/docz/compare/v0.12.15...v0.12.16) (2018-12-13)
+
+**Note:** Version bump only for package docz-example-basic
+
+
+
+
+
+## [0.12.15](https://github.com/pedronauck/docz/compare/v0.12.14...v0.12.15) (2018-12-04)
+
+**Note:** Version bump only for package docz-example-basic
+
+
+
+
+
+## [0.12.14](https://github.com/pedronauck/docz/compare/v0.12.13...v0.12.14) (2018-12-04)
+
+**Note:** Version bump only for package docz-example-basic
+
+
+
+
+
+## [0.12.13](https://github.com/pedronauck/docz/compare/v0.12.12...v0.12.13) (2018-11-23)
+
+**Note:** Version bump only for package docz-example-basic
+
+
+
+
+
+## [0.12.12](https://github.com/pedronauck/docz/compare/v0.12.11...v0.12.12) (2018-11-16)
+
+**Note:** Version bump only for package docz-example-basic
+
+
+
+
+
+## [0.12.11](https://github.com/pedronauck/docz/compare/v0.12.10...v0.12.11) (2018-11-15)
+
+**Note:** Version bump only for package docz-example-basic
+
+
+
+
+
+## [0.12.10](https://github.com/pedronauck/docz/compare/v0.12.9...v0.12.10) (2018-11-15)
+
+**Note:** Version bump only for package docz-example-basic
+
+
+
+
+
+## [0.12.9](https://github.com/pedronauck/docz/compare/v0.12.8...v0.12.9) (2018-11-01)
+
+**Note:** Version bump only for package docz-example-basic
+
+
+
+
+
+## [0.12.8](https://github.com/pedronauck/docz/compare/v0.12.7...v0.12.8) (2018-10-31)
+
+**Note:** Version bump only for package docz-example-basic
+
+
+
+
+
+## [0.12.7](https://github.com/pedronauck/docz/compare/v0.12.6...v0.12.7) (2018-10-30)
+
+**Note:** Version bump only for package docz-example-basic
+
+
+
+
+
+## [0.12.6](https://github.com/pedronauck/docz/compare/v0.12.5...v0.12.6) (2018-10-30)
+
+
+### Bug Fixes
+
+* **docz:** conditionally description column on PropsTable ([#385](https://github.com/pedronauck/docz/issues/385)) ([829a3aa](https://github.com/pedronauck/docz/commit/829a3aa)), closes [#427](https://github.com/pedronauck/docz/issues/427) [#421](https://github.com/pedronauck/docz/issues/421)
+
+
+
+
+
+<a name="0.12.5"></a>
+## [0.12.5](https://github.com/pedronauck/docz/compare/v0.12.4...v0.12.5) (2018-09-30)
+
+**Note:** Version bump only for package docz-example-basic
+
+
+
+
+
+<a name="0.12.4"></a>
+## [0.12.4](https://github.com/pedronauck/docz/compare/v0.12.3...v0.12.4) (2018-09-28)
+
+**Note:** Version bump only for package docz-example-basic
+
+
+
+
+
+<a name="0.12.3"></a>
+## [0.12.3](https://github.com/pedronauck/docz/compare/v0.12.2...v0.12.3) (2018-09-28)
+
+**Note:** Version bump only for package docz-example-basic
+
+
+
+
+
+<a name="0.11.2"></a>
+## [0.11.2](https://github.com/pedronauck/docz/compare/v0.11.1...v0.11.2) (2018-09-11)
+
+**Note:** Version bump only for package docz-example-basic
+
+
+
+
+
+<a name="0.11.1"></a>
+## [0.11.1](https://github.com/pedronauck/docz/compare/v0.11.0...v0.11.1) (2018-09-07)
+
+**Note:** Version bump only for package docz-example-basic
+
+
+
+
+
+<a name="0.11.0"></a>
+# [0.11.0](https://github.com/pedronauck/docz/compare/v0.10.3...v0.11.0) (2018-09-02)
+
+
+### Features
+
+* **docz:** move docz/docz-core to dev dependency on examples ([e7153a4](https://github.com/pedronauck/docz/commit/e7153a4))
+
+
+
+
+
+<a name="0.10.3"></a>
+## [0.10.3](https://github.com/pedronauck/docz/compare/v0.9.6...v0.10.3) (2018-08-16)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.10.2"></a>
+## [0.10.2](https://github.com/pedronauck/docz/compare/v0.10.1...v0.10.2) (2018-08-13)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.10.1"></a>
+## [0.10.1](https://github.com/pedronauck/docz/compare/v0.10.0...v0.10.1) (2018-08-13)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.10.0"></a>
+# [0.10.0](https://github.com/pedronauck/docz/compare/v0.9.6...v0.10.0) (2018-08-13)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.9.6"></a>
+## [0.9.6](https://github.com/pedronauck/docz/compare/v0.9.5...v0.9.6) (2018-08-06)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.9.5"></a>
+## [0.9.5](https://github.com/pedronauck/docz/compare/v0.9.4...v0.9.5) (2018-08-04)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.9.4"></a>
+## [0.9.4](https://github.com/pedronauck/docz/compare/v0.9.4-beta.1...v0.9.4) (2018-08-04)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.9.3"></a>
+## [0.9.3](https://github.com/pedronauck/docz/compare/v0.9.2...v0.9.3) (2018-08-03)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.9.2"></a>
+## [0.9.2](https://github.com/pedronauck/docz/compare/v0.9.1...v0.9.2) (2018-08-02)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.9.1"></a>
+## [0.9.1](https://github.com/pedronauck/docz/compare/v0.9.0...v0.9.1) (2018-08-02)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.9.0"></a>
+# [0.9.0](https://github.com/pedronauck/docz/compare/v0.9.0-beta.1...v0.9.0) (2018-08-02)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.9.0-beta.1"></a>
+# [0.9.0-beta.1](https://github.com/pedronauck/docz/compare/v0.9.0-beta.0...v0.9.0-beta.1) (2018-08-01)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.9.0-beta.0"></a>
+# [0.9.0-beta.0](https://github.com/pedronauck/docz/compare/v0.8.0...v0.9.0-beta.0) (2018-08-01)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.8.0"></a>
+# [0.8.0](https://github.com/pedronauck/docz/compare/v0.7.1...v0.8.0) (2018-07-28)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.7.1"></a>
+## [0.7.1](https://github.com/pedronauck/docz/compare/v0.7.0...v0.7.1) (2018-07-24)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.7.0"></a>
+# [0.7.0](https://github.com/pedronauck/docz/compare/v0.6.2...v0.7.0) (2018-07-23)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.6.2"></a>
+## [0.6.2](https://github.com/pedronauck/docz/compare/v0.6.1...v0.6.2) (2018-07-20)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.6.1"></a>
+## [0.6.1](https://github.com/pedronauck/docz/compare/v0.6.0...v0.6.1) (2018-07-19)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.6.0"></a>
+# [0.6.0](https://github.com/pedronauck/docz/compare/v0.5.9...v0.6.0) (2018-07-19)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.5.9"></a>
+## [0.5.9](https://github.com/pedronauck/docz/compare/v0.5.8...v0.5.9) (2018-07-16)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.5.8"></a>
+## [0.5.8](https://github.com/pedronauck/docz/compare/v0.5.7...v0.5.8) (2018-07-11)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.5.7"></a>
+## [0.5.7](https://github.com/pedronauck/docz/compare/v0.5.6...v0.5.7) (2018-07-11)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.5.6"></a>
+## [0.5.6](https://github.com/pedronauck/docz/compare/v0.5.5...v0.5.6) (2018-07-11)
+
+
+### Bug Fixes
+
+* **docz:** add theme config transform before merge ([dc3448a](https://github.com/pedronauck/docz/commit/dc3448a))
+
+
+
+
+<a name="0.5.5"></a>
+## [0.5.5](https://github.com/pedronauck/docz/compare/v0.5.4...v0.5.5) (2018-07-07)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.5.4"></a>
+## [0.5.4](https://github.com/pedronauck/docz/compare/v0.5.3...v0.5.4) (2018-07-07)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.5.3"></a>
+## [0.5.3](https://github.com/pedronauck/docz/compare/v0.5.2...v0.5.3) (2018-07-05)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.5.2"></a>
+## [0.5.2](https://github.com/pedronauck/docz/compare/v0.5.1...v0.5.2) (2018-07-05)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.5.1"></a>
+## [0.5.1](https://github.com/pedronauck/docz/compare/v0.3.4...v0.5.1) (2018-07-03)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.5.0"></a>
+# [0.5.0](https://github.com/pedronauck/docz/compare/v0.3.4...v0.5.0) (2018-07-03)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.4.0"></a>
+# [0.4.0](https://github.com/pedronauck/docz/compare/v0.3.4...v0.4.0) (2018-06-30)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.3.4"></a>
+## [0.3.4](https://github.com/pedronauck/docz/compare/v0.3.3...v0.3.4) (2018-06-26)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.3.3"></a>
+## [0.3.3](https://github.com/pedronauck/docz/compare/v0.3.2...v0.3.3) (2018-06-26)
+
+
+### Bug Fixes
+
+* **docz-core:** copy templates files for dist ([#88](https://github.com/pedronauck/docz/issues/88)) ([5e4b98d](https://github.com/pedronauck/docz/commit/5e4b98d))
+
+
+
+
+<a name="0.3.2"></a>
+## [0.3.2](https://github.com/pedronauck/docz/compare/v0.3.1...v0.3.2) (2018-06-25)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.3.1"></a>
+## [0.3.1](https://github.com/pedronauck/docz/compare/v0.2.11...v0.3.1) (2018-06-25)
+
+
+### Features
+
+* **docz-default-theme:** dark mode and responsiveness ([#87](https://github.com/pedronauck/docz/issues/87)) ([a4db115](https://github.com/pedronauck/docz/commit/a4db115)), closes [#81](https://github.com/pedronauck/docz/issues/81)
+
+
+
+
+<a name="0.3.0"></a>
+# [0.3.0](https://github.com/pedronauck/docz/compare/v0.3.0-beta.0...v0.3.0) (2018-06-25)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.3.0-beta.0"></a>
+# [0.3.0-beta.0](https://github.com/pedronauck/docz/compare/v0.2.11...v0.3.0-beta.0) (2018-06-25)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.2.11"></a>
+## [0.2.11](https://github.com/pedronauck/docz/compare/v0.2.10...v0.2.11) (2018-06-22)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.2.10"></a>
+## [0.2.10](https://github.com/pedronauck/docz/compare/v0.2.9...v0.2.10) (2018-06-21)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.2.9"></a>
+## [0.2.9](https://github.com/pedronauck/docz/compare/v0.2.8...v0.2.9) (2018-06-21)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.2.8"></a>
+## [0.2.8](https://github.com/pedronauck/docz/compare/v0.2.7...v0.2.8) (2018-06-21)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.2.7"></a>
+## [0.2.7](https://github.com/pedronauck/docz/compare/v0.2.6...v0.2.7) (2018-06-20)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.2.6"></a>
+## [0.2.6](https://github.com/pedronauck/docz/compare/v0.2.5...v0.2.6) (2018-06-17)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.2.5"></a>
+## [0.2.5](https://github.com/pedronauck/docz/compare/v0.2.4...v0.2.5) (2018-06-15)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.2.4"></a>
+## [0.2.4](https://github.com/pedronauck/docz/compare/v0.2.3...v0.2.4) (2018-06-13)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.2.3"></a>
+## [0.2.3](https://github.com/pedronauck/docz/compare/v0.2.2...v0.2.3) (2018-06-13)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.2.2"></a>
+## [0.2.2](https://github.com/pedronauck/docz/compare/v0.2.1...v0.2.2) (2018-06-12)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.2.1"></a>
+## [0.2.1](https://github.com/pedronauck/docz/compare/v0.2.0...v0.2.1) (2018-06-12)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.2.0"></a>
+# [0.2.0](https://github.com/pedronauck/docz/compare/v0.2.0-beta.2...v0.2.0) (2018-06-11)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.2.0-beta.2"></a>
+# [0.2.0-beta.2](https://github.com/doczjs/docz/compare/v0.2.0-beta.1...v0.2.0-beta.2) (2018-06-10)
+
+
+### Bug Fixes
+
+* **docz-core:** autolink headings ([0b8369d](https://github.com/doczjs/docz/commit/0b8369d))
+
+
+
+
+<a name="0.2.0-beta.1"></a>
+# [0.2.0-beta.1](https://github.com/doczjs/docz/compare/v0.2.0-beta.0...v0.2.0-beta.1) (2018-06-10)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.2.0-beta.0"></a>
+# [0.2.0-beta.0](https://github.com/doczjs/docz/compare/v0.1.2-beta.6...v0.2.0-beta.0) (2018-06-10)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.1.2-beta.6"></a>
+## [0.1.2-beta.6](https://github.com/doczjs/docz/compare/v0.1.2-beta.5...v0.1.2-beta.6) (2018-06-09)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.1.2-beta.5"></a>
+## [0.1.2-beta.5](https://github.com/doczjs/docz/compare/v0.1.2-beta.4...v0.1.2-beta.5) (2018-06-09)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.1.2-beta.4"></a>
+## [0.1.2-beta.4](https://github.com/doczjs/docz/compare/v0.1.2-beta.3...v0.1.2-beta.4) (2018-06-09)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.1.2-beta.3"></a>
+## [0.1.2-beta.3](https://github.com/doczjs/docz/compare/v0.1.2-beta.2...v0.1.2-beta.3) (2018-06-09)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.1.2-beta.2"></a>
+## [0.1.2-beta.2](https://github.com/doczjs/docz/compare/v0.1.2-beta.1...v0.1.2-beta.2) (2018-06-09)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.1.2-beta.1"></a>
+## [0.1.2-beta.1](https://github.com/doczjs/docz/compare/v0.1.2-beta.0...v0.1.2-beta.1) (2018-06-09)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.1.2-beta.0"></a>
+## [0.1.2-beta.0](https://github.com/doczjs/docz/compare/v0.1.1...v0.1.2-beta.0) (2018-06-02)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.1.1-beta.6"></a>
+## [0.1.1-beta.6](https://github.com/doczjs/docz/compare/v0.1.1-beta.5...v0.1.1-beta.6) (2018-06-01)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.1.1-beta.5"></a>
+## [0.1.1-beta.5](https://github.com/doczjs/docz/compare/v0.1.1-beta.4...v0.1.1-beta.5) (2018-06-01)
+
+
+### Bug Fixes
+
+* **load-cfg:** add namedExports options ([d36194d](https://github.com/doczjs/docz/commit/d36194d))
+
+
+
+
+<a name="0.1.1-beta.4"></a>
+## [0.1.1-beta.4](https://github.com/doczjs/docz/compare/v0.1.1-beta.3...v0.1.1-beta.4) (2018-05-29)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.1.1-beta.3"></a>
+## [0.1.1-beta.3](https://github.com/doczjs/docz/compare/v0.1.1-beta.2...v0.1.1-beta.3) (2018-05-29)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.1.1-beta.2"></a>
+## [0.1.1-beta.2](https://github.com/doczjs/docz/compare/v0.1.1-beta.0...v0.1.1-beta.2) (2018-05-29)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.1.1-beta.1"></a>
+## [0.1.1-beta.1](https://github.com/doczjs/docz/compare/v0.1.1-beta.0...v0.1.1-beta.1) (2018-05-29)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.1.1-beta.0"></a>
+## [0.1.1-beta.0](https://github.com/doczjs/docz/compare/v0.1.0...v0.1.1-beta.0) (2018-05-29)
+
+
+
+
+**Note:** Version bump only for package docz-example-basic
+
+<a name="0.1.0"></a>
+# 0.1.0 (2018-05-29)
+
+
+### Bug Fixes
+
+* **docz-core:** config watch for directory operations ([43fa7ab](https://github.com/doczjs/docz/commit/43fa7ab))
+* **docz-core:** create plugin to fix paragraph parse on mdx ([42b4f05](https://github.com/doczjs/docz/commit/42b4f05))
+* **docz-core:** packages splitting ([d2e74ee](https://github.com/doczjs/docz/commit/d2e74ee))
+* **docz-example-basic:** package name ([dec5713](https://github.com/doczjs/docz/commit/dec5713))
+
+
+### Features
+
+* **docz:** add groups feature ([9652b30](https://github.com/doczjs/docz/commit/9652b30))
+* add basic monorepo structure ([5a977ed](https://github.com/doczjs/docz/commit/5a977ed))
+* **docz:** add components parser ([a4127d9](https://github.com/doczjs/docz/commit/a4127d9))
+* **docz:** add custom routes for docs ([8458d91](https://github.com/doczjs/docz/commit/8458d91))
+* **docz-core:** add build command ([ef7abd2](https://github.com/doczjs/docz/commit/ef7abd2))
+* **docz-core:** add hot reload ([9ebe65d](https://github.com/doczjs/docz/commit/9ebe65d))
+* **docz-core:** add playground code parse section ([6bbf158](https://github.com/doczjs/docz/commit/6bbf158))
+* **docz-core:** set babel on the fly ([672be49](https://github.com/doczjs/docz/commit/672be49))
+* add component props parse feature ([987627d](https://github.com/doczjs/docz/commit/987627d))
+* add support for highlight code sections ([19bf7ea](https://github.com/doczjs/docz/commit/19bf7ea))
+* **docz-core:** use websockets instead of generate json to process entries ([e0773a0](https://github.com/doczjs/docz/commit/e0773a0))
+* **docz-theme-default:** start logic to create theme feature ([900cf2b](https://github.com/doczjs/docz/commit/900cf2b))
+* refac to use mdx ([04b59e5](https://github.com/doczjs/docz/commit/04b59e5))

--- a/examples/now/README.md
+++ b/examples/now/README.md
@@ -1,0 +1,37 @@
+# Docz Now Deployment example
+
+## Using `create-docz-app`
+
+```sh
+npx create-docz-app docz-app-now --example now
+# or
+yarn create docz-app docz-app-now --example now
+```
+
+## Download manually
+
+```sh
+curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/now
+mv now docz-example-now
+docz-example-now
+```
+
+## Setup
+
+```sh
+yarn # npm i
+```
+
+## Run
+
+```sh
+yarn dev # npm run dev
+```
+
+## Deploy
+
+```sh
+yarn deploy
+```
+
+Note that by default `docz` generates the output site in `.docz/public` to change that add a `dest` field to your `doczrc.js` with the path you want to generate the code in.

--- a/examples/now/doczrc.js
+++ b/examples/now/doczrc.js
@@ -1,0 +1,3 @@
+export default {
+  menu: ['Getting Started', 'Components'],
+}

--- a/examples/now/now.json
+++ b/examples/now/now.json
@@ -1,0 +1,4 @@
+{
+  "builds": [{ "src": ".docz/public/**", "use": "@now/static" }],
+  "routes": [{ "src": "/(.*)", "dest": ".docz/public/$1" }]
+}

--- a/examples/now/package.json
+++ b/examples/now/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "docz-example-now",
+  "version": "2.0.0-rc.2",
+  "license": "MIT",
+  "files": [
+    "src/",
+    "doczrc.js",
+    "package.json"
+  ],
+  "scripts": {
+    "dev": "docz dev",
+    "//": "temporary hack below fixed with next docz version. Used for running docz on CI",
+    "dev:once": "npx kill-port 3000 && (npm run dev &) && npx wait-on http-get://localhost:3000 && npx kill-port 3000",
+    "build": "npm run dev:once && docz build",
+    "deploy": "npm run build && now"
+  },
+  "dependencies": {
+    "@emotion/core": "^10.0.14",
+    "@emotion/styled": "^10.0.14",
+    "prop-types": "^15.7.2",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6",
+    "scheduler": "^0.15.0"
+  },
+  "devDependencies": {
+    "docz": "2.0.0-rc.5",
+    "now": "^16.1.2"
+  }
+}

--- a/examples/now/src/components/Alert.jsx
+++ b/examples/now/src/components/Alert.jsx
@@ -1,0 +1,28 @@
+import React, { Fragment } from 'react'
+import styled from '@emotion/styled'
+import t from 'prop-types'
+
+const kinds = {
+  info: '#5352ED',
+  positive: '#2ED573',
+  negative: '#FF4757',
+  warning: '#FFA502',
+}
+
+const AlertStyled = styled('div')`
+  padding: 15px 20px;
+  background: white;
+  border-radius: 3px;
+  color: white;
+  background: ${({ kind = 'info' }) => kinds[kind]};
+`
+
+export const Alert = props => <AlertStyled {...props} />
+
+Alert.propTypes = {
+  kind: t.oneOf(['info', 'positive', 'negative', 'warning']),
+}
+
+Alert.defaultProps = {
+  kind: 'info',
+}

--- a/examples/now/src/components/Alert.mdx
+++ b/examples/now/src/components/Alert.mdx
@@ -1,0 +1,28 @@
+---
+name: Alert
+menu: Components
+---
+
+import { Playground, Props } from 'docz'
+import { Alert } from './Alert'
+
+# Alert
+
+## Properties
+
+<Props of={Alert} />
+
+## Basic usage
+
+<Playground>
+  <Alert>Some message</Alert>
+</Playground>
+
+## Using different kinds
+
+<Playground>
+  <Alert kind="info">Some message</Alert>
+  <Alert kind="positive">Some message</Alert>
+  <Alert kind="negative">Some message</Alert>
+  <Alert kind="warning">Some message</Alert>
+</Playground>

--- a/examples/now/src/components/Button.jsx
+++ b/examples/now/src/components/Button.jsx
@@ -1,0 +1,83 @@
+import React from 'react'
+import styled from '@emotion/styled'
+import t from 'prop-types'
+
+const scales = {
+  small: `
+    padding: 5px 10px;
+    font-size: 14px;
+  `,
+  normal: `
+    padding: 10px 20px;
+    font-size: 16px;
+  `,
+  big: `
+    padding: 20px 30px;
+    font-size: 18px;
+  `,
+}
+
+const kind = outline => (bg, color) => {
+  const boxShadowColor = outline ? bg : 'transparent'
+  const backgroundColor = outline ? 'transparent' : bg
+
+  return `
+    background: ${backgroundColor};
+    box-shadow: inset 0 0 0 1px ${boxShadowColor};
+    color: ${outline ? bg : color};
+    transition: all .3s;
+
+    &:hover {
+      box-shadow: inset 0 0 0 1000px ${boxShadowColor};
+      color: ${color};
+    }
+  `
+}
+
+const kinds = outline => {
+  const get = kind(outline)
+
+  return {
+    primary: get('#1FB6FF', 'white'),
+    secondary: get('#5352ED', 'white'),
+    cancel: get('#FF4949', 'white'),
+    dark: get('#273444', 'white'),
+    gray: get('#8492A6', 'white'),
+  }
+}
+
+const getScale = ({ scale = 'normal' }) => scales[scale]
+const getKind = ({ kind = 'primary', outline = false }) => kinds(outline)[kind]
+
+const ButtonStyled = styled('button')`
+  ${getKind};
+  ${getScale};
+  cursor: pointer;
+  margin: 3px 5px;
+  border: none;
+  border-radius: 3px;
+`
+
+export const Button = ({ children, ...props }) => (
+  <ButtonStyled {...props}>{children}</ButtonStyled>
+)
+
+Button.propTypes = {
+  /**
+   * This is a pretty good description for this prop
+   * Button type. Learn more about `type` attribute [at MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type)
+   */
+  type: t.oneOf(['button', 'submit', 'reset']),
+  /**
+   * This is a __pretty good__ description for this prop
+   */
+  scales: t.oneOf(['small', 'normal', 'big']),
+  kind: t.oneOf(['primary', 'secondary', 'cancel', 'dark', 'gray']),
+  outline: t.bool.isRequired,
+}
+
+Button.defaultProps = {
+  scales: 'normal',
+  kind: 'primary',
+  outline: false,
+}

--- a/examples/now/src/components/Button.mdx
+++ b/examples/now/src/components/Button.mdx
@@ -1,0 +1,57 @@
+---
+name: Button
+menu: Components
+---
+
+import { Playground, Props } from 'docz'
+import { Button } from './Button'
+
+# Button
+
+Buttons make common actions more obvious and help users more easily perform them. Buttons use labels and sometimes icons to communicate the action that will occur when the user touches them.
+
+### Best practices
+
+- Group buttons logically into sets based on usage and importance.
+- Ensure that button actions are clear and consistent.
+- The main action of a group set can be a primary button.
+- Select a single button variation and do not mix them.
+
+## Properties
+
+<Props of={Button} />
+
+## Basic usage
+
+<Playground>
+  <Button>Click me</Button>
+</Playground>
+
+## With different sizes
+
+<Playground>
+  <Button scale="small">Click me</Button>
+  <Button scale="normal">Click me</Button>
+  <Button scale="big">Click me</Button>
+</Playground>
+
+## With different colors
+
+<Playground>
+  <Button kind="primary">Click me</Button>
+  <Button kind="secondary">Click me</Button>
+  <Button kind="cancel">Click me</Button>
+  <Button kind="dark">Click me</Button>
+  <Button kind="gray">Click me</Button>
+</Playground>
+
+## Outlined
+
+<Playground>
+  <Button kind="primary" outline>Click me</Button>
+  <Button kind="secondary" outline>Click me</Button>
+  <Button kind="cancel" outline>Click me</Button>
+  <Button kind="dark" outline>Click me</Button>
+  <Button kind="gray" outline>Click me</Button>
+</Playground>
+

--- a/examples/now/src/index.mdx
+++ b/examples/now/src/index.mdx
@@ -1,0 +1,20 @@
+---
+name: Getting Started
+route: /
+---
+
+# Getting Started
+
+Design systems enable teams to build better products faster by making design reusable—reusability makes scale possible. This is the heart and primary value of design systems. A design system is a collection of reusable components, guided by clear standards, that can be assembled together to build any number of applications.
+
+Regardless of the technologies and tools behind them, a successful design system follows these guiding principles:
+
+- **It’s consistent**. The way components are built and managed follows a predictable pattern.
+- **It’s self-contained**. Your design system is treated as a standalone dependency.
+- **It’s reusable**. You’ve built components so they can be reused in many contexts.
+- **It’s accessible**. Applications built with your design system are usable by as many people as possible, no matter how they access the web.
+- **It’s robust**. No matter the product or platform to which your design system is applied, it should perform with grace and minimal bugs.
+
+## Consistency
+
+Your first, most important task when starting out is to define the rules of your system, document them, and ensure that everyone follows them. When you have clearly documented code standards and best practices in place, designers and developers from across your organization can easily use and, more importantly, contribute to your design system.


### PR DESCRIPTION
### Description

Added an example for deploying with now.

To try it : 
```sh
npx create-docz-app docz-and-now --example now 
```