### PR TITLE
chore: Add node_modules to git ignore list

### DIFF
--- a/examples/gatsby/.gitignore
+++ b/examples/gatsby/.gitignore
@@ -1,3 +1,6 @@
 # gatsby files
 .cache/
 public
+
+# dependencies
+node_modules


### PR DESCRIPTION
### Description

This pull request adds `node_modules` to our .gitignore file. This way, you don't accidentally end up including it in your git repo.

### Review

- [ ] Check that node_modules is spelled correctly