### PR TITLE
fix(docz-core): use react from parent directory

### DIFF
--- a/core/docz-core/package.json
+++ b/core/docz-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docz-core",
-  "version": "2.0.0-rc.13",
+  "version": "2.0.0-rc.21",
   "description": "All docz core logic of bundle and parsing is included on this package",
   "license": "MIT",
   "main": "dist/index.js",
@@ -17,6 +17,7 @@
     "fix": "yarn lint --fix",
     "lint": "yarn eslint . --ext .ts,.tsx",
     "precommit": "lint-staged",
+    "prepare": "yarn build",
     "test": "yarn jest"
   },
   "dependencies": {

--- a/core/docz-core/package.json
+++ b/core/docz-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docz-core",
-  "version": "2.0.0-rc.12",
+  "version": "2.0.0-rc.13",
   "description": "All docz core logic of bundle and parsing is included on this package",
   "license": "MIT",
   "main": "dist/index.js",

--- a/core/docz-core/src/bundler/machine/services/create-resources.ts
+++ b/core/docz-core/src/bundler/machine/services/create-resources.ts
@@ -67,6 +67,11 @@ const writeGatsbyConfig = async ({ args, isDoczRepo }: ServerMachineCtx) => {
   })
 }
 
+const writeGatsbyConfigNode = async () => {
+  const outputPath = path.join(paths.docz, 'gatsby-node.js')
+  await outputFileFromTemplate('gatsby-node.tpl.js', outputPath)
+}
+
 const copyGatsbyConfigFile = async (from: string, to: string) => {
   const filepath = path.join(paths.root, from)
   const dest = path.join(paths.docz, to)
@@ -78,8 +83,8 @@ const copyGatsbyConfigFile = async (from: string, to: string) => {
 const writeGatsbyConfigCustom = async () =>
   copyGatsbyConfigFile('gatsby-config.js', 'gatsby-config.custom.js')
 
-const writeGatsbyNode = async () =>
-  copyGatsbyConfigFile('gatsby-node.js', 'gatsby-node.js')
+const writeGatsbyNodeCustom = async () =>
+  copyGatsbyConfigFile('gatsby-node.js', 'gatsby-node.custom.js')
 
 const writeGatsbySSR = async () =>
   copyGatsbyConfigFile('gatsby-ssr.js', 'gatsby-ssr.js')
@@ -95,8 +100,9 @@ export const createResources = async (ctx: ServerMachineCtx) => {
     await writeEslintRc(ctx)
     await writeNotFound()
     await writeGatsbyConfig(ctx)
+    await writeGatsbyConfigNode()
     await writeGatsbyConfigCustom()
-    await writeGatsbyNode()
+    await writeGatsbyNodeCustom()
     await writeGatsbyBrowser()
     await writeGatsbySSR()
   } catch (err) {

--- a/core/docz-core/src/utils/create-deps.ts
+++ b/core/docz-core/src/utils/create-deps.ts
@@ -51,13 +51,9 @@ const getCoreDeps = async ({ isDoczRepo }: ServerMachineCtx, pkg: any) => {
 export const createDeps = async (ctx: ServerMachineCtx) => {
   const filepath = path.join(paths.root, 'package.json')
   const pkg = await fs.readJSON(filepath, { throws: false })
-
+  const dependencies = pkg.dependencies
   return {
-    dependencies: {
-      ...pkg.dependencies,
-      react: '../node_modules/react',
-      'react-dom': '../node_modules/react-dom',
-    },
+    dependencies,
     devDependencies: {
       ...pkg.devDependencies,
       ...(await getDeps(REQUIRED_DEV_DEPS, ctx, pkg)),

--- a/core/docz-core/src/utils/create-deps.ts
+++ b/core/docz-core/src/utils/create-deps.ts
@@ -53,7 +53,11 @@ export const createDeps = async (ctx: ServerMachineCtx) => {
   const pkg = await fs.readJSON(filepath, { throws: false })
 
   return {
-    dependencies: pkg.dependencies,
+    dependencies: {
+      ...pkg.dependencies,
+      react: '../node_modules/react',
+      'react-dom': '../node_modules/react-dom',
+    },
     devDependencies: {
       ...pkg.devDependencies,
       ...(await getDeps(REQUIRED_DEV_DEPS, ctx, pkg)),

--- a/core/docz-core/templates/gatsby-node.tpl.js
+++ b/core/docz-core/templates/gatsby-node.tpl.js
@@ -1,0 +1,11 @@
+const path = require('path')
+
+exports.onCreateWebpackConfig = ({ actions }) => {
+  actions.setWebpackConfig({
+    resolve: {
+      alias: {
+        react: path.resolve('../node_modules/react'),
+      },
+    },
+  })
+}

--- a/core/docz/package.json
+++ b/core/docz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docz",
-  "version": "2.0.0-rc.12",
+  "version": "2.0.0-rc.13",
   "description": "It's has never been so easy to documents your things!",
   "license": "MIT",
   "main": "dist/index.js",

--- a/core/docz/package.json
+++ b/core/docz/package.json
@@ -28,7 +28,7 @@
     "array-sort": "^1.0.0",
     "capitalize": "^2.0.0",
     "docz-components": "^2.0.0-rc.12",
-    "docz-core": "^2.0.0-rc.12",
+    "docz-core": "^2.0.0-rc.13",
     "fast-deep-equal": "^2.0.1",
     "gatsby": "^2.13.27",
     "lodash": "^4.17.14",

--- a/core/docz/package.json
+++ b/core/docz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docz",
-  "version": "2.0.0-rc.13",
+  "version": "2.0.0-rc.21",
   "description": "It's has never been so easy to documents your things!",
   "license": "MIT",
   "main": "dist/index.js",
@@ -28,7 +28,7 @@
     "array-sort": "^1.0.0",
     "capitalize": "^2.0.0",
     "docz-components": "^2.0.0-rc.12",
-    "docz-core": "^2.0.0-rc.13",
+    "docz-core": "^2.0.0-rc.21",
     "fast-deep-equal": "^2.0.1",
     "gatsby": "^2.13.27",
     "lodash": "^4.17.14",

--- a/core/gatsby-theme-docz/package.json
+++ b/core/gatsby-theme-docz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-theme-docz",
-  "version": "2.0.0-rc.12",
+  "version": "2.0.0-rc.13",
   "description": "Gatsby theme created to use Docz",
   "license": "MIT",
   "author": "Pedro Nauck (pedronauck@gmail.com)",

--- a/core/gatsby-theme-docz/package.json
+++ b/core/gatsby-theme-docz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-theme-docz",
-  "version": "2.0.0-rc.13",
+  "version": "2.0.0-rc.21",
   "description": "Gatsby theme created to use Docz",
   "license": "MIT",
   "author": "Pedro Nauck (pedronauck@gmail.com)",
@@ -46,7 +46,7 @@
     "rehype-slug": "^2.0.3",
     "remark-docz": "^2.0.0-rc.1",
     "remark-frontmatter": "^1.3.2",
-    "theme-ui": "^0.2.14",
+    "theme-ui": "^0.2.38",
     "typescript": "3.5.3",
     "typography-theme-moraga": "^0.16.19",
     "yargs": "^13.3.0"

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -21,6 +21,6 @@
     "scheduler": "^0.15.0"
   },
   "devDependencies": {
-    "docz": "2.0.0-rc.9"
+    "docz": "next"
   }
 }

--- a/examples/flow/package.json
+++ b/examples/flow/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@babel/preset-flow": "^7.0.0",
-    "docz": "2.0.0-rc.9",
+    "docz": "next",
     "flow-bin": "^0.102.0",
     "flow-typed": "^2.6.0"
   }

--- a/examples/images/package.json
+++ b/examples/images/package.json
@@ -20,6 +20,6 @@
     "scheduler": "^0.15.0"
   },
   "devDependencies": {
-    "docz": "2.0.0-rc.9"
+    "docz": "next"
   }
 }

--- a/examples/now/package.json
+++ b/examples/now/package.json
@@ -23,7 +23,7 @@
     "scheduler": "^0.15.0"
   },
   "devDependencies": {
-    "docz": "2.0.0-rc.9",
+    "docz": "next",
     "now": "^16.1.2"
   }
 }

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -23,6 +23,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",
-    "docz": "2.0.0-rc.9"
+    "docz": "next"
   }
 }

--- a/examples/styled-components/package.json
+++ b/examples/styled-components/package.json
@@ -18,6 +18,6 @@
     "styled-components": "^4.3.2"
   },
   "devDependencies": {
-    "docz": "2.0.0-rc.9"
+    "docz": "next"
   }
 }

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -22,6 +22,6 @@
   "devDependencies": {
     "@types/react": "^16.8.23",
     "@types/react-dom": "^16.8.4",
-    "docz": "2.0.0-rc.9"
+    "docz": "next"
   }
 }


### PR DESCRIPTION
Configures webpack in `.docz` to use React from the parent node_modules to avoid using two React versions in the same app. 

#1050 #1037