### PR TITLE
feat(docz-core) parse both tsx? and jsx? files when using Typescript

### DIFF
--- a/core/docz-core/src/states/props.ts
+++ b/core/docz-core/src/states/props.ts
@@ -26,7 +26,7 @@ const getPattern = (config: Config) => {
     .map(entry => typeof entry === 'string' && `!**/${entry}`)
     .filter(Boolean)
     .concat([
-      path.join(src, ts ? '**/*.{ts,tsx}' : '**/*.{js,jsx,mjs}'),
+      path.join(src, ts ? '**/*.{ts,tsx,js,jsx,mjs}' : '**/*.{js,jsx,mjs}'),
       '!**/node_modules',
       '!**/doczrc.js',
     ]) as string[]

--- a/core/docz-core/src/utils/docgen/index.ts
+++ b/core/docz-core/src/utils/docgen/index.ts
@@ -8,7 +8,10 @@ import { tsParser } from './typescript'
 export const docgen = async (files: string[], config: Config) => {
   const cwd = paths.getRootDir(config)
   const tsconfig = await findUp('tsconfig.json', { cwd })
+  const tsFiles = files.filter(file => file.match(/\.(tsx|ts)$/))
+  const jsFiles = files.filter(file => file.match(/\.(js|jsx|mjs)$/))
+
   return config.typescript
-    ? tsParser(files, config, tsconfig)
-    : jsParser(files, config)
+    ? tsParser(tsFiles, config, tsconfig).concat(jsParser(jsFiles, config))
+    : jsParser(jsFiles, config)
 }


### PR DESCRIPTION
### Description

when set `useTypescript : true` ,the **Props** dosen't render , which component end  with .js and .jsx

### Review

- [ ] Check the copy
- [ ] ...
- [ ] ...

### Pre-merge checklist

- [ ] ...
- [ ] ...

### Screenshots

| Before | After |
| ------ | ----- |
| Image  | Image |