### PR TITLE
Allow for no tsconfig

### DIFF
--- a/core/docz-core/src/utils/docgen/typescript.ts
+++ b/core/docz-core/src/utils/docgen/typescript.ts
@@ -205,7 +205,7 @@ export const tsParser = (
   config: Config,
   tsconfig?: string
 ) => {
-  if (!tsconfig) return null
+  if (!tsconfig) return []
   const filesToLoad = checkFilesOnCache(files, config)
   const propsOnCache = getPropsOnCache()
   if (!filesToLoad.length) return propsOnCache


### PR DESCRIPTION
If no tsconfig is passed, don't crash the build process

### Description

If you set typescript to true, and you don't have a tsconfig.json file specified, the dev task crashes. 

This fixes it (I think), but things still might crash due to the missing tsconfig.json file.