### PR TITLE
2.0.0-rc.32 : expose gatsby actions to plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,34 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.0.0-rc.32](https://github.com/pedronauck/docz/compare/v2.0.0-rc.1...v2.0.0-rc.32) (2019-09-04)
+
+### Bug Fixes
+
+- **docz:** add @emotion/core dependency ([52126df](https://github.com/pedronauck/docz/commit/52126df))
+- **docz:** better default playground component ([80b1c66](https://github.com/pedronauck/docz/commit/80b1c66))
+- **docz:** bump docz-core version ([c56e0c6](https://github.com/pedronauck/docz/commit/c56e0c6))
+- **docz:** initialize components context with defaultComponents ([a808795](https://github.com/pedronauck/docz/commit/a808795))
+- **docz:** use playground from docz-components ([52874c4](https://github.com/pedronauck/docz/commit/52874c4))
+- **docz-components:** better prop types for playground ([f35f3ca](https://github.com/pedronauck/docz/commit/f35f3ca))
+- **docz-components:** fix development example ([faf2134](https://github.com/pedronauck/docz/commit/faf2134))
+- **docz-components:** fix syntax highlighting in Playground ([c72c575](https://github.com/pedronauck/docz/commit/c72c575))
+- **docz-components:** typo boder -> border ([1246b19](https://github.com/pedronauck/docz/commit/1246b19))
+- **docz-core:** make onCreateWebpackConfig extendable ([8968a6c](https://github.com/pedronauck/docz/commit/8968a6c))
+- **docz-core:** run init on build if docz is not initialized ([26aa7f6](https://github.com/pedronauck/docz/commit/26aa7f6))
+- **docz-core:** set yarn production to false to download all deps ([2b4cc6b](https://github.com/pedronauck/docz/commit/2b4cc6b))
+- **docz-core:** use react from parent directory ([#1053](https://github.com/pedronauck/docz/issues/1053)) ([b55b786](https://github.com/pedronauck/docz/commit/b55b786))
+- **gatsby-theme-docz:** expose gatsby actions to plugin ([66546a4](https://github.com/pedronauck/docz/commit/66546a4))
+- **gatsby-theme-docz:** fix style differences between dev and build ([9cb5237](https://github.com/pedronauck/docz/commit/9cb5237))
+- **gatsby-theme-docz:** replace iframe in playground with div [#984](https://github.com/pedronauck/docz/issues/984) [#1035](https://github.com/pedronauck/docz/issues/1035) ([4214180](https://github.com/pedronauck/docz/commit/4214180))
+
+### Features
+
+- **docz-component:** initialize ([73fafd1](https://github.com/pedronauck/docz/commit/73fafd1))
+- **docz-components:** working playground ([344ffbb](https://github.com/pedronauck/docz/commit/344ffbb))
+- **docz-core:** add docz init command ([43cdeca](https://github.com/pedronauck/docz/commit/43cdeca))
+- **docz-gatsby-monorepo:** add example showing docz usage in a monorepo ([241c757](https://github.com/pedronauck/docz/commit/241c757))
+
 # [2.0.0-rc.31](https://github.com/pedronauck/docz/compare/v2.0.0-rc.1...v2.0.0-rc.31) (2019-09-03)
 
 ### Bug Fixes

--- a/core/docz-components/CHANGELOG.md
+++ b/core/docz-components/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.0.0-rc.32](https://github.com/pedronauck/docz/compare/v2.0.0-rc.1...v2.0.0-rc.32) (2019-09-04)
+
+### Bug Fixes
+
+- **docz-components:** better prop types for playground ([f35f3ca](https://github.com/pedronauck/docz/commit/f35f3ca))
+- **docz-components:** fix development example ([faf2134](https://github.com/pedronauck/docz/commit/faf2134))
+- **docz-components:** fix syntax highlighting in Playground ([c72c575](https://github.com/pedronauck/docz/commit/c72c575))
+- **docz-components:** typo boder -> border ([1246b19](https://github.com/pedronauck/docz/commit/1246b19))
+
+### Features
+
+- **docz-component:** initialize ([73fafd1](https://github.com/pedronauck/docz/commit/73fafd1))
+- **docz-components:** working playground ([344ffbb](https://github.com/pedronauck/docz/commit/344ffbb))
+
 # [2.0.0-rc.31](https://github.com/pedronauck/docz/compare/v2.0.0-rc.1...v2.0.0-rc.31) (2019-09-03)
 
 ### Bug Fixes

--- a/core/docz-components/package.json
+++ b/core/docz-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docz-components",
-  "version": "2.0.0-rc.31",
+  "version": "2.0.0-rc.32",
   "main": "dist/index.js",
   "module": "dist/docz-components.esm.js",
   "typings": "dist/index.d.ts",

--- a/core/docz-core/CHANGELOG.md
+++ b/core/docz-core/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.0.0-rc.32](https://github.com/pedronauck/docz/compare/v2.0.0-rc.1...v2.0.0-rc.32) (2019-09-04)
+
+### Bug Fixes
+
+- **docz-core:** make onCreateWebpackConfig extendable ([8968a6c](https://github.com/pedronauck/docz/commit/8968a6c))
+- **docz-core:** run init on build if docz is not initialized ([26aa7f6](https://github.com/pedronauck/docz/commit/26aa7f6))
+- **docz-core:** set yarn production to false to download all deps ([2b4cc6b](https://github.com/pedronauck/docz/commit/2b4cc6b))
+- **docz-core:** use react from parent directory ([#1053](https://github.com/pedronauck/docz/issues/1053)) ([b55b786](https://github.com/pedronauck/docz/commit/b55b786))
+
+### Features
+
+- **docz-core:** add docz init command ([43cdeca](https://github.com/pedronauck/docz/commit/43cdeca))
+
 # [2.0.0-rc.31](https://github.com/pedronauck/docz/compare/v2.0.0-rc.1...v2.0.0-rc.31) (2019-09-03)
 
 ### Bug Fixes

--- a/core/docz-core/package.json
+++ b/core/docz-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docz-core",
-  "version": "2.0.0-rc.31",
+  "version": "2.0.0-rc.32",
   "description": "All docz core logic of bundle and parsing is included on this package",
   "license": "MIT",
   "main": "dist/index.js",

--- a/core/docz/CHANGELOG.md
+++ b/core/docz/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.0.0-rc.32](https://github.com/pedronauck/docz/compare/v2.0.0-rc.1...v2.0.0-rc.32) (2019-09-04)
+
+### Bug Fixes
+
+- **docz:** add @emotion/core dependency ([52126df](https://github.com/pedronauck/docz/commit/52126df))
+- **docz:** better default playground component ([80b1c66](https://github.com/pedronauck/docz/commit/80b1c66))
+- **docz:** bump docz-core version ([c56e0c6](https://github.com/pedronauck/docz/commit/c56e0c6))
+- **docz:** initialize components context with defaultComponents ([a808795](https://github.com/pedronauck/docz/commit/a808795))
+- **docz:** use playground from docz-components ([52874c4](https://github.com/pedronauck/docz/commit/52874c4))
+- **docz-components:** fix syntax highlighting in Playground ([c72c575](https://github.com/pedronauck/docz/commit/c72c575))
+- **docz-core:** use react from parent directory ([#1053](https://github.com/pedronauck/docz/issues/1053)) ([b55b786](https://github.com/pedronauck/docz/commit/b55b786))
+
+### Features
+
+- **docz-component:** initialize ([73fafd1](https://github.com/pedronauck/docz/commit/73fafd1))
+
 # [2.0.0-rc.31](https://github.com/pedronauck/docz/compare/v2.0.0-rc.1...v2.0.0-rc.31) (2019-09-03)
 
 ### Bug Fixes

--- a/core/docz/package.json
+++ b/core/docz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docz",
-  "version": "2.0.0-rc.31",
+  "version": "2.0.0-rc.32",
   "description": "It's has never been so easy to documents your things!",
   "license": "MIT",
   "main": "dist/index.js",
@@ -27,8 +27,8 @@
     "@mdx-js/react": "^1.0.27",
     "array-sort": "^1.0.0",
     "capitalize": "^2.0.0",
-    "docz-components": "2.0.0-rc.31",
-    "docz-core": "2.0.0-rc.31",
+    "docz-components": "2.0.0-rc.32",
+    "docz-core": "2.0.0-rc.32",
     "fast-deep-equal": "^2.0.1",
     "gatsby": "^2.13.27",
     "lodash": "^4.17.14",

--- a/core/gatsby-theme-docz/CHANGELOG.md
+++ b/core/gatsby-theme-docz/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.0.0-rc.32](https://github.com/pedronauck/docz/compare/v2.0.0-rc.1...v2.0.0-rc.32) (2019-09-04)
+
+### Bug Fixes
+
+- **docz-core:** use react from parent directory ([#1053](https://github.com/pedronauck/docz/issues/1053)) ([b55b786](https://github.com/pedronauck/docz/commit/b55b786))
+- **gatsby-theme-docz:** expose gatsby actions to plugin ([66546a4](https://github.com/pedronauck/docz/commit/66546a4))
+- **gatsby-theme-docz:** fix style differences between dev and build ([9cb5237](https://github.com/pedronauck/docz/commit/9cb5237))
+- **gatsby-theme-docz:** replace iframe in playground with div [#984](https://github.com/pedronauck/docz/issues/984) [#1035](https://github.com/pedronauck/docz/issues/1035) ([4214180](https://github.com/pedronauck/docz/commit/4214180))
+
 # [2.0.0-rc.31](https://github.com/pedronauck/docz/compare/v2.0.0-rc.1...v2.0.0-rc.31) (2019-09-03)
 
 ### Bug Fixes

--- a/core/gatsby-theme-docz/lib/onCreateWebpackConfig.js
+++ b/core/gatsby-theme-docz/lib/onCreateWebpackConfig.js
@@ -28,5 +28,5 @@ module.exports = async (params, opts) => {
     })
   }
 
-  run('onCreateWebpackConfig', config, stage === 'develop', args)
+  run('onCreateWebpackConfig', actions, stage === 'develop', args, config)
 }

--- a/core/gatsby-theme-docz/package.json
+++ b/core/gatsby-theme-docz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-theme-docz",
-  "version": "2.0.0-rc.31",
+  "version": "2.0.0-rc.32",
   "description": "Gatsby theme created to use Docz",
   "license": "MIT",
   "author": "Pedro Nauck (pedronauck@gmail.com)",
@@ -24,7 +24,7 @@
     "babel-plugin-export-metadata": "^2.0.0-rc.1",
     "copy-text-to-clipboard": "^2.1.0",
     "docz": "2.0.0-rc.9",
-    "docz-core": "2.0.0-rc.31",
+    "docz-core": "2.0.0-rc.32",
     "emotion-theming": "^10.0.14",
     "fs-extra": "^8.1.0",
     "gatsby": "^2.13.27",

--- a/examples/basic/CHANGELOG.md
+++ b/examples/basic/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.0.0-rc.32](https://github.com/pedronauck/docz/compare/v2.0.0-rc.1...v2.0.0-rc.32) (2019-09-04)
+
+### Bug Fixes
+
+- **docz-core:** set yarn production to false to download all deps ([2b4cc6b](https://github.com/pedronauck/docz/commit/2b4cc6b))
+- **docz-core:** use react from parent directory ([#1053](https://github.com/pedronauck/docz/issues/1053)) ([b55b786](https://github.com/pedronauck/docz/commit/b55b786))
+
 # [2.0.0-rc.31](https://github.com/pedronauck/docz/compare/v2.0.0-rc.1...v2.0.0-rc.31) (2019-09-03)
 
 ### Bug Fixes

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docz-example-basic",
   "private": true,
-  "version": "2.0.0-rc.31",
+  "version": "2.0.0-rc.32",
   "license": "MIT",
   "files": [
     "src/",

--- a/examples/flow/CHANGELOG.md
+++ b/examples/flow/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.0.0-rc.32](https://github.com/pedronauck/docz/compare/v2.0.0-rc.1...v2.0.0-rc.32) (2019-09-04)
+
+### Bug Fixes
+
+- **docz-core:** use react from parent directory ([#1053](https://github.com/pedronauck/docz/issues/1053)) ([b55b786](https://github.com/pedronauck/docz/commit/b55b786))
+
 # [2.0.0-rc.31](https://github.com/pedronauck/docz/compare/v2.0.0-rc.1...v2.0.0-rc.31) (2019-09-03)
 
 ### Bug Fixes

--- a/examples/flow/package.json
+++ b/examples/flow/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docz-example-flow",
   "private": true,
-  "version": "2.0.0-rc.31",
+  "version": "2.0.0-rc.32",
   "license": "MIT",
   "files": [
     "src/",

--- a/examples/gatsby/CHANGELOG.md
+++ b/examples/gatsby/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.0.0-rc.32](https://github.com/pedronauck/docz/compare/v2.0.0-rc.1...v2.0.0-rc.32) (2019-09-04)
+
+**Note:** Version bump only for package docz-example-gatsby
+
 # [2.0.0-rc.31](https://github.com/pedronauck/docz/compare/v2.0.0-rc.1...v2.0.0-rc.31) (2019-09-03)
 
 **Note:** Version bump only for package docz-example-gatsby

--- a/examples/gatsby/package.json
+++ b/examples/gatsby/package.json
@@ -2,7 +2,7 @@
   "name": "docz-example-gatsby",
   "private": true,
   "description": "Example of how to integrate docz with gatsby as a theme",
-  "version": "2.0.0-rc.31",
+  "version": "2.0.0-rc.32",
   "keywords": [
     "gatsby",
     "docz"

--- a/examples/images/CHANGELOG.md
+++ b/examples/images/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.0.0-rc.32](https://github.com/pedronauck/docz/compare/v2.0.0-rc.1...v2.0.0-rc.32) (2019-09-04)
+
+### Bug Fixes
+
+- **docz-core:** use react from parent directory ([#1053](https://github.com/pedronauck/docz/issues/1053)) ([b55b786](https://github.com/pedronauck/docz/commit/b55b786))
+
 # [2.0.0-rc.31](https://github.com/pedronauck/docz/compare/v2.0.0-rc.1...v2.0.0-rc.31) (2019-09-03)
 
 ### Bug Fixes

--- a/examples/images/package.json
+++ b/examples/images/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "docz-example-images",
-  "version": "2.0.0-rc.31",
+  "version": "2.0.0-rc.32",
   "license": "MIT",
   "files": [
     "src/",

--- a/examples/monorepo/CHANGELOG.md
+++ b/examples/monorepo/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.0.0-rc.32](https://github.com/pedronauck/docz/compare/v2.0.0-rc.1...v2.0.0-rc.32) (2019-09-04)
+
+### Features
+
+- **docz-gatsby-monorepo:** add example showing docz usage in a monorepo ([241c757](https://github.com/pedronauck/docz/commit/241c757))
+
 # [2.0.0-rc.31](https://github.com/pedronauck/docz/compare/v2.0.0-rc.1...v2.0.0-rc.31) (2019-09-03)
 
 ### Features

--- a/examples/monorepo/package.json
+++ b/examples/monorepo/package.json
@@ -5,7 +5,7 @@
     "packages/docs-site"
   ],
   "name": "docz-gatsby-monorepo",
-  "version": "2.0.0-rc.31",
+  "version": "2.0.0-rc.32",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/examples/now/CHANGELOG.md
+++ b/examples/now/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.0.0-rc.32](https://github.com/pedronauck/docz/compare/v2.0.0-rc.1...v2.0.0-rc.32) (2019-09-04)
+
+### Bug Fixes
+
+- **docz-core:** use react from parent directory ([#1053](https://github.com/pedronauck/docz/issues/1053)) ([b55b786](https://github.com/pedronauck/docz/commit/b55b786))
+
 # [2.0.0-rc.31](https://github.com/pedronauck/docz/compare/v2.0.0-rc.1...v2.0.0-rc.31) (2019-09-03)
 
 ### Bug Fixes

--- a/examples/now/package.json
+++ b/examples/now/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "docz-example-now",
-  "version": "2.0.0-rc.31",
+  "version": "2.0.0-rc.32",
   "license": "MIT",
   "files": [
     "src/",

--- a/examples/react-native/CHANGELOG.md
+++ b/examples/react-native/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.0.0-rc.32](https://github.com/pedronauck/docz/compare/v2.0.0-rc.1...v2.0.0-rc.32) (2019-09-04)
+
+### Bug Fixes
+
+- **docz-core:** use react from parent directory ([#1053](https://github.com/pedronauck/docz/issues/1053)) ([b55b786](https://github.com/pedronauck/docz/commit/b55b786))
+
 # [2.0.0-rc.31](https://github.com/pedronauck/docz/compare/v2.0.0-rc.1...v2.0.0-rc.31) (2019-09-03)
 
 ### Bug Fixes

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "docz-example-react-native",
-  "version": "2.0.0-rc.31",
+  "version": "2.0.0-rc.32",
   "license": "MIT",
   "files": [
     "src/",

--- a/examples/styled-components/CHANGELOG.md
+++ b/examples/styled-components/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.0.0-rc.32](https://github.com/pedronauck/docz/compare/v2.0.0-rc.1...v2.0.0-rc.32) (2019-09-04)
+
+### Bug Fixes
+
+- **docz-core:** use react from parent directory ([#1053](https://github.com/pedronauck/docz/issues/1053)) ([b55b786](https://github.com/pedronauck/docz/commit/b55b786))
+
 # [2.0.0-rc.31](https://github.com/pedronauck/docz/compare/v2.0.0-rc.1...v2.0.0-rc.31) (2019-09-03)
 
 ### Bug Fixes

--- a/examples/styled-components/package.json
+++ b/examples/styled-components/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "docz-example-styled-components",
-  "version": "2.0.0-rc.31",
+  "version": "2.0.0-rc.32",
   "license": "MIT",
   "files": [
     "src/",

--- a/examples/typescript/CHANGELOG.md
+++ b/examples/typescript/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.0.0-rc.32](https://github.com/pedronauck/docz/compare/v2.0.0-rc.1...v2.0.0-rc.32) (2019-09-04)
+
+### Bug Fixes
+
+- **docz-core:** use react from parent directory ([#1053](https://github.com/pedronauck/docz/issues/1053)) ([b55b786](https://github.com/pedronauck/docz/commit/b55b786))
+
 # [2.0.0-rc.31](https://github.com/pedronauck/docz/compare/v2.0.0-rc.1...v2.0.0-rc.31) (2019-09-03)
 
 ### Bug Fixes

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "docz-example-typescript",
-  "version": "2.0.0-rc.31",
+  "version": "2.0.0-rc.32",
   "license": "MIT",
   "files": [
     "src/",

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "lerna": "3.1.3",
   "packages": ["core/**/*", "other-packages/**/*"],
-  "version": "2.0.0-rc.31",
+  "version": "2.0.0-rc.32",
   "npmClient": "yarn",
   "useWorkspaces": true
 }


### PR DESCRIPTION
- fix(gatsby-theme-docz): expose gatsby actions to plugin

Fixes #1060
