### PR TITLE
feat: adds theme path override option

### DIFF
--- a/core/docz-core/__tests__/config.test.ts
+++ b/core/docz-core/__tests__/config.test.ts
@@ -1,7 +1,7 @@
 import * as path from 'path'
 import { setArgs } from '../src/config/argv'
 import { getBaseConfig } from '../src/config/docz'
-import { getThemeDir } from '../src/config/paths'
+import { getThemesDir } from '../src/config/paths'
 import yargs from 'yargs'
 
 describe('config.argv & config.docz', () => {
@@ -20,7 +20,7 @@ describe('getThemeDir', () => {
     //@ts-ignore
     const config = getBaseConfig(argv, {})
 
-    expect(getThemeDir(config)).toBe(path.join(config.root, '/src'))
+    expect(getThemesDir(config)).toBe(path.join(config.root, '/src'))
   })
 
   test('returns correct path for custom themesDir entry', () => {
@@ -28,6 +28,6 @@ describe('getThemeDir', () => {
     //@ts-ignore
     const config = getBaseConfig(argv, { themesDir: 'theme' })
 
-    expect(getThemeDir(config)).toBe(path.join(config.root, '/theme'))
+    expect(getThemesDir(config)).toBe(path.join(config.root, '/theme'))
   })
 })

--- a/core/docz-core/__tests__/config.test.ts
+++ b/core/docz-core/__tests__/config.test.ts
@@ -30,4 +30,12 @@ describe('getThemeDir', () => {
 
     expect(getThemesDir(config)).toBe(path.join(config.root, '/theme'))
   })
+
+  test('custom themesDir entries with trailing slashes are handled correctly', () => {
+    const { argv } = setArgs(yargs)
+    //@ts-ignore
+    const config = getBaseConfig(argv, { themesDir: 'theme/' })
+
+    expect(getThemesDir(config)).toBe(path.join(config.root, '/theme'))
+  })
 })

--- a/core/docz-core/__tests__/config.test.ts
+++ b/core/docz-core/__tests__/config.test.ts
@@ -1,18 +1,33 @@
+import * as path from 'path'
 import { setArgs } from '../src/config/argv'
 import { getBaseConfig } from '../src/config/docz'
+import { getThemeDir } from '../src/config/paths'
+import yargs from 'yargs'
+
 describe('config.argv & config.docz', () => {
   test('works', () => {
-    const yargs = {
-      argv: {},
-      option: jest.fn().mockImplementation((key, value) => {
-        yargs.argv[value.alias ? value.alias : key] = value
-        return yargs
-      }),
-    }
     const { argv } = setArgs(yargs)
     // expect(argv).toMatchInlineSnapshot(`undefined`)
     //@ts-ignore
     getBaseConfig(argv, {})
     // expect(c)
+  })
+})
+
+describe('getThemeDir', () => {
+  test('returns src/ for default config', () => {
+    const { argv } = setArgs(yargs)
+    //@ts-ignore
+    const config = getBaseConfig(argv, {})
+
+    expect(getThemeDir(config)).toBe(path.join(config.root, '/src'))
+  })
+
+  test('returns correct path for custom themesDir entry', () => {
+    const { argv } = setArgs(yargs)
+    //@ts-ignore
+    const config = getBaseConfig(argv, { themesDir: 'theme' })
+
+    expect(getThemeDir(config)).toBe(path.join(config.root, '/theme'))
   })
 })

--- a/core/docz-core/src/bundler/machine/actions.ts
+++ b/core/docz-core/src/bundler/machine/actions.ts
@@ -17,8 +17,8 @@ const ensureFile = (filename: string, toDelete?: string) => {
   }
 }
 
-export const ensureFiles = () => {
-  const themeDirs = glob.sync('src/gatsby-theme-**', {
+export const ensureFiles = ({ args }: ServerMachineCtx) => {
+  const themeDirs = glob.sync(path.join(args.themesDir, '/gatsby-theme-**'), {
     cwd: paths.docz,
     onlyDirectories: true,
   })

--- a/core/docz-core/src/bundler/machine/services/watch-files.ts
+++ b/core/docz-core/src/bundler/machine/services/watch-files.ts
@@ -7,6 +7,20 @@ import * as paths from '../../../config/paths'
 import { createWatcher } from '../../../states/config'
 import { ServerMachineCtx as Context } from '../context'
 
+const replaceThemeDir = (filepath: string, args: Config) => {
+  // Make the path to a given  absolute`filepath` relative:
+  const relFilePath = path.relative(filepath, paths.getThemeDir(args))
+  // => '/gatsby-theme-docz/**/index.tsx'
+
+  // Prefix with `src`
+  const newRelFilePath = path.join('src', relFilePath)
+  // => 'src/gatsby-theme-docz/**/index.tsx'
+
+  // Finally make filepath absolute again
+  return path.resolve(paths.root, newRelFilePath)
+  // => '/Users/.../theme/a/docz-project/src/gatsby-theme-docz/**/index.tsx'
+}
+
 const watchGatsbyThemeFiles = (args: Config) => {
   const watcher = createWatcher(
     path.join(args.themesDir, 'gatsby-theme-**/**/*'),
@@ -14,7 +28,7 @@ const watchGatsbyThemeFiles = (args: Config) => {
   )
   const copy = (filepath: string) => {
     const src = path.resolve(paths.root, filepath)
-    const dest = path.resolve(paths.docz, filepath)
+    const dest = path.resolve(paths.docz, replaceThemeDir(filepath, args))
     fs.copySync(src, dest)
   }
   const remove = (filepath: string) => {

--- a/core/docz-core/src/bundler/machine/services/watch-files.ts
+++ b/core/docz-core/src/bundler/machine/services/watch-files.ts
@@ -7,9 +7,9 @@ import * as paths from '../../../config/paths'
 import { createWatcher } from '../../../states/config'
 import { ServerMachineCtx as Context } from '../context'
 
-const replaceThemeDir = (filepath: string, args: Config) => {
+const replaceThemesDir = (filepath: string, args: Config) => {
   // Make the path to a given  absolute`filepath` relative:
-  const relFilePath = path.relative(filepath, paths.getThemeDir(args))
+  const relFilePath = path.relative(filepath, paths.getThemesDir(args))
   // => '/gatsby-theme-docz/**/index.tsx'
 
   // Prefix with `src`
@@ -28,7 +28,7 @@ const watchGatsbyThemeFiles = (args: Config) => {
   )
   const copy = (filepath: string) => {
     const src = path.resolve(paths.root, filepath)
-    const dest = path.resolve(paths.docz, replaceThemeDir(filepath, args))
+    const dest = path.resolve(paths.docz, replaceThemesDir(filepath, args))
     fs.copySync(src, dest)
   }
   const remove = (filepath: string) => {

--- a/core/docz-core/src/bundler/machine/services/watch-files.ts
+++ b/core/docz-core/src/bundler/machine/services/watch-files.ts
@@ -8,7 +8,10 @@ import { createWatcher } from '../../../states/config'
 import { ServerMachineCtx as Context } from '../context'
 
 const watchGatsbyThemeFiles = (args: Config) => {
-  const watcher = createWatcher('src/gatsby-theme-**/**/*', args)
+  const watcher = createWatcher(
+    path.join(args.themesDir, 'gatsby-theme-**/**/*'),
+    args
+  )
   const copy = (filepath: string) => {
     const src = path.resolve(paths.root, filepath)
     const dest = path.resolve(paths.docz, filepath)

--- a/core/docz-core/src/bundler/machine/services/watch-files.ts
+++ b/core/docz-core/src/bundler/machine/services/watch-files.ts
@@ -7,18 +7,20 @@ import * as paths from '../../../config/paths'
 import { createWatcher } from '../../../states/config'
 import { ServerMachineCtx as Context } from '../context'
 
+/**
+ * Maps a given relative 'filepath' from 'themesDir/...' to 'src/...'
+ */
 const replaceThemesDir = (filepath: string, args: Config) => {
-  // Make the path to a given  absolute`filepath` relative:
-  const relFilePath = path.relative(filepath, paths.getThemesDir(args))
-  // => '/gatsby-theme-docz/**/index.tsx'
+  // Make the path to a given relative`filepath` relative to themesDir:
+  const rawFilePath = path.relative(
+    paths.getThemesDir(args),
+    path.resolve(paths.root, filepath)
+  )
+  // => e.g. '/gatsby-theme-docz/**/index.tsx'
 
-  // Prefix with `src`
-  const newRelFilePath = path.join('src', relFilePath)
+  // Prefix with 'src':
+  return path.join('src', rawFilePath)
   // => 'src/gatsby-theme-docz/**/index.tsx'
-
-  // Finally make filepath absolute again
-  return path.resolve(paths.root, newRelFilePath)
-  // => '/Users/.../theme/a/docz-project/src/gatsby-theme-docz/**/index.tsx'
 }
 
 const watchGatsbyThemeFiles = (args: Config) => {

--- a/core/docz-core/src/config/argv.ts
+++ b/core/docz-core/src/config/argv.ts
@@ -65,13 +65,14 @@ export interface Argv {
 }
 
 export interface Config extends Argv {
+  docgenConfig: DocgenConfig
+  hastPlugins: any[]
+  mdPlugins: any[]
+  menu: Menu[]
   paths: paths.Paths
   plugins: Plugin[]
-  mdPlugins: any[]
-  hastPlugins: any[]
-  menu: Menu[]
   themeConfig: ThemeConfig
-  docgenConfig: DocgenConfig
+  themesDir: string
   filterComponents: (files: string[]) => string[]
 }
 

--- a/core/docz-core/src/config/docz.ts
+++ b/core/docz-core/src/config/docz.ts
@@ -12,6 +12,7 @@ import { Plugin } from '../lib/Plugin'
 const toOmit = ['_', '$0', 'version', 'help']
 export const doczRcBaseConfig = {
   themeConfig: {},
+  themesDir: 'src',
   docgenConfig: {},
   menu: [],
   plugins: [],

--- a/core/docz-core/src/config/paths.ts
+++ b/core/docz-core/src/config/paths.ts
@@ -27,6 +27,10 @@ export const getRootDir = (config: any) => {
   return isDoczProject ? path.resolve(root, '../') : root
 }
 
+export const getThemeDir = (config: { themesDir: string }) => {
+  return path.join(getRootDir(config), config.themesDir)
+}
+
 export interface Paths {
   root: string
   templates: string
@@ -48,6 +52,7 @@ export interface Paths {
 
   checkIsDoczProject: (config: any) => boolean
   getRootDir: (config: any) => string
+  getThemeDir: (config: any) => string
   getDist: (dest: string) => string
   distPublic: (dest: string) => string
 

--- a/core/docz-core/src/config/paths.ts
+++ b/core/docz-core/src/config/paths.ts
@@ -27,7 +27,7 @@ export const getRootDir = (config: any) => {
   return isDoczProject ? path.resolve(root, '../') : root
 }
 
-export const getThemeDir = (config: { themesDir: string }) => {
+export const getThemesDir = (config: { themesDir: string }) => {
   return path.join(getRootDir(config), config.themesDir)
 }
 
@@ -52,7 +52,7 @@ export interface Paths {
 
   checkIsDoczProject: (config: any) => boolean
   getRootDir: (config: any) => string
-  getThemeDir: (config: any) => string
+  getThemesDir: (config: any) => string
   getDist: (dest: string) => string
   distPublic: (dest: string) => string
 

--- a/core/docz-core/src/config/paths.ts
+++ b/core/docz-core/src/config/paths.ts
@@ -28,7 +28,8 @@ export const getRootDir = (config: any) => {
 }
 
 export const getThemesDir = (config: { themesDir: string }) => {
-  return path.join(getRootDir(config), config.themesDir)
+  // resolve normalizes the new path and removes trailing slashes
+  return path.resolve(path.join(getRootDir(config), config.themesDir))
 }
 
 export interface Paths {


### PR DESCRIPTION
### Description
Resolves #997 


- [x] Have the custom path override default to src in the docz config
- [x] Add argument to ensureFiles with the path blob.
- [x] Update the watch function here to use path from config
- [x] Make sure to write them to the destination directory as src/gatsby-theme-* independently of the variable to make sure Gatsby interprets them correctly.
