### PR TITLE
feat(gatsby-theme-docz): apply theme background color to content

### DIFF
--- a/core/gatsby-theme-docz/src/components/Layout/styles.js
+++ b/core/gatsby-theme-docz/src/components/Layout/styles.js
@@ -18,6 +18,7 @@ export const wrapper = {
 }
 
 export const content = {
+  backgroundColor: 'background',
   position: 'relative',
   maxWidth: 960,
   py: 5,


### PR DESCRIPTION
### Description

make sure to use theme background color 

#1100 