### PR TITLE
feat(gatsby-theme-docz): allow gatsby-remark- plugins

### DIFF
--- a/core/gatsby-theme-docz/gatsby-config.js
+++ b/core/gatsby-theme-docz/gatsby-config.js
@@ -28,10 +28,15 @@ const getRehypePlugins = () => {
   return plugins
 }
 
+const getGatsbyRemarkPlugins = () => {
+  return []
+}
+
 module.exports = opts => {
   const config = getDoczConfig(opts)
   const mdPlugins = getRemarkPlugins()
   const hastPlugins = getRehypePlugins()
+  const gatsbyRemarkPlugins = getGatsbyRemarkPlugins()
 
   return {
     plugins: [
@@ -47,6 +52,10 @@ module.exports = opts => {
             config && config.hastPlugins
               ? config.hastPlugins.concat(hastPlugins)
               : hastPlugins,
+          gatsbyRemarkPlugins:
+            config && config.gatsbyRemarkPlugins
+              ? config.gatsbyRemarkPlugins.concat(gatsbyRemarkPlugins)
+              : gatsbyRemarkPlugins,
           defaultLayouts: {
             default: path.join(__dirname, 'src/base/Layout.js'),
           },


### PR DESCRIPTION
This PR allows users to use `gatsby-remark-*` plugins with `gatsby-theme-docz`.  

Currently, there is not easy way to override/extend `gatsby-config.js` in a child theme (see https://github.com/gatsbyjs/gatsby/issues/16697) to configure an already defined plugin (like `gatsby-plugin-mdx`). At least, not that I'm aware. 

The motivation behind this PR was trying to setup Docz as a gatsby theme with support for Mermaid graphs processing in fenced blocks using remark. Example:

````markdown
---
name: Hello
---

# Hello

This is an example using mermaid

```mermaid
graph LR
    Start --> Stop
```
````

Example of `gatsby-config`:

```js
module.exports = {
  plugins: [
    {
      resolve: "gatsby-theme-docz",
      options: {
        mdPlugins: [],
        gatsbyRemarkPlugins: [
          {
            resolve: `gatsby-remark-mermaid`
          }
        ]
      }
    }
  ]
}
```