### PR TITLE
fix(gatsby-theme-docz): typecheck default props

### DIFF
--- a/core/gatsby-theme-docz/src/components/Props/index.js
+++ b/core/gatsby-theme-docz/src/components/Props/index.js
@@ -5,12 +5,25 @@ import { jsx } from 'theme-ui'
 import { ChevronDown, ChevronUp } from '../Icons'
 import * as styles from './styles'
 
+const getDefaultValue = ({ defaultValue, type }) => {
+  if (!defaultValue.value || !type.name) return null
+  if (defaultValue.value === "''") {
+    return <em>[Empty string]</em>
+  }
+  if (type.name === 'string') {
+    return <em>{value.replace(/\'/g, '"')}</em>
+  }
+  if (typeof defaultValue.value === 'object' && defaultValue.value.toString) {
+    return defaultValue.value.toString()
+  }
+  return <em>{defaultValue.value}</em>
+}
+
 export const Prop = ({ propName, prop, getPropType }) => {
   const [showing, setShowing] = useState(false)
   if (!prop.type && !prop.flowType) return null
 
   const toggle = () => setShowing(s => !s)
-
   return (
     <div sx={styles.line} data-testid="prop">
       <div sx={styles.content}>
@@ -22,11 +35,7 @@ export const Prop = ({ propName, prop, getPropType }) => {
         </div>
         {prop.defaultValue && (
           <div sx={styles.defaultValue} data-testid="prop-default-value">
-            {prop.defaultValue.value === "''" ? (
-              <em>[Empty String]</em>
-            ) : (
-              <em>{prop.defaultValue.value.replace(/\'/g, '"')}</em>
-            )}
+            {getDefaultValue(prop)}
           </div>
         )}
         <div sx={styles.right}>


### PR DESCRIPTION
### Description

Fixes #1130 

Every parsed prop gets a defaultValue of the type `string` in dev. But it seems like the prod build converts the value from a string to the actual value `true` based on the screenshot in the issue, could this be true?