### PR TITLE
fix(gatsby-theme-docz) default to text in code blocks if no language

### DIFF
--- a/core/gatsby-theme-docz/src/components/Code/index.js
+++ b/core/gatsby-theme-docz/src/components/Code/index.js
@@ -6,7 +6,9 @@ import { jsx, Styled } from 'theme-ui'
 import { usePrismTheme } from '~utils/theme'
 
 export const Code = ({ children, className: outerClassName }) => {
-  const [language] = outerClassName.replace(/language-/, '').split(' ')
+  const [language] = outerClassName
+    ? outerClassName.replace(/language-/, '').split(' ')
+    : ['text']
   const theme = usePrismTheme()
 
   return (
@@ -18,7 +20,7 @@ export const Code = ({ children, className: outerClassName }) => {
     >
       {({ className, style, tokens, getLineProps, getTokenProps }) => (
         <Styled.pre
-          className={`${outerClassName} ${className}`}
+          className={`${outerClassName || ''} ${className}`}
           style={style}
           data-testid="code"
         >


### PR DESCRIPTION
### Description

Defaults to `"text"` as language if no language is specified on code block as mentioned [here](https://github.com/doczjs/docz/issues/1042#issuecomment-531435802)