### PR TITLE
fix: use dist dir when watching files

### DIFF
--- a/dev-env/basic/dev.js
+++ b/dev-env/basic/dev.js
@@ -46,7 +46,7 @@ const getDestinationPath = (name, outputDir = '') => {
 
 const watchPackage = async (name, outputDir) => {
   const sourcePath = path.join(rootPath, `core/${name}/${outputDir}`)
-  const destinationPath = getDestinationPath(name)
+  const destinationPath = getDestinationPath(name, outputDir)
   const sourceRootPath = path.join(rootPath, `core/${name}/`)
   const dev = runCommand(`yarn run dev`, { cwd: sourceRootPath })
   try {


### PR DESCRIPTION
### Description

The dev command should output to the correct `dist `-folder except for the theme-package.