### PR TITLE
feat(gatsby-theme-docz): #1112 move menu icon

### DIFF
--- a/core/gatsby-theme-docz/src/components/Header/index.js
+++ b/core/gatsby-theme-docz/src/components/Header/index.js
@@ -3,10 +3,11 @@ import { jsx, Box, Flex, useColorMode } from 'theme-ui'
 import { useConfig, useCurrentDoc } from 'docz'
 
 import * as styles from './styles'
-import { Edit, Sun, Github } from '../Icons'
+import { Edit, Menu, Sun, Github } from '../Icons'
 import { Logo } from '../Logo'
 
-export const Header = () => {
+export const Header = props => {
+  const { onOpen } = props
   const config = useConfig()
   const { edit = true, ...doc } = useCurrentDoc()
   const [colorMode, setColorMode] = useColorMode()
@@ -17,6 +18,11 @@ export const Header = () => {
 
   return (
     <div sx={styles.wrapper} data-testid={'header'}>
+      <Box sx={styles.menuIcon}>
+        <button sx={styles.menuButton} onClick={onOpen}>
+          <Menu size={25} />
+        </button>
+      </Box>
       <div sx={styles.innerContainer}>
         <Logo />
         <Flex>

--- a/core/gatsby-theme-docz/src/components/Header/styles.js
+++ b/core/gatsby-theme-docz/src/components/Header/styles.js
@@ -1,8 +1,10 @@
 import * as mixins from '~utils/mixins'
+import { media } from '~theme/breakpoints'
 
 export const wrapper = {
   bg: 'header.bg',
   position: 'relative',
+  zIndex: 1,
   borderBottom: t => `1px solid ${t.colors.border}`,
 }
 
@@ -12,6 +14,23 @@ export const innerContainer = {
   py: '24px',
   position: 'relative',
   justifyContent: 'space-between',
+}
+
+export const menuIcon = {
+  display: 'none',
+  position: 'absolute',
+  top: 'calc(100% + 15px)',
+  left: 30,
+  [media.tablet]: {
+    display: 'block',
+  },
+}
+
+export const menuButton = {
+  ...mixins.ghostButton,
+  color: 'header.text',
+  opacity: 0.5,
+  cursor: 'pointer',
 }
 
 export const headerButton = {
@@ -24,9 +43,7 @@ export const headerButton = {
   color: 'header.button.color',
   fontSize: 0,
   fontWeight: 600,
-  ':hover': {
-    cursor: 'pointer',
-  },
+  cursor: 'pointer',
 }
 
 export const editButton = {

--- a/core/gatsby-theme-docz/src/components/Layout/index.js
+++ b/core/gatsby-theme-docz/src/components/Layout/index.js
@@ -1,30 +1,22 @@
 /** @jsx jsx */
 import { useRef, useState } from 'react'
-import { jsx, Box, Layout as BaseLayout, Main, Container } from 'theme-ui'
+import { jsx, Layout as BaseLayout, Main, Container } from 'theme-ui'
 import { Global } from '@emotion/core'
 
 import global from '~theme/global'
 import { Header } from '../Header'
 import { Sidebar } from '../Sidebar'
-import { Menu } from '../Icons'
 import * as styles from './styles'
 
 export const Layout = ({ children }) => {
   const [open, setOpen] = useState(false)
   const nav = useRef()
 
-  const handleMenu = () => {
-    setOpen(s => !s)
-    if (!nav.current) return
-    const navLink = nav.current.querySelector('a')
-    if (navLink) navLink.focus()
-  }
-
   return (
     <BaseLayout sx={{ '& > div': { flex: '1 1 auto' } }} data-testid="layout">
       <Global styles={global} />
       <Main sx={styles.main}>
-        <Header nav={nav} onOpen={setOpen} />
+        <Header onOpen={() => setOpen(s => !s)} />
         <div sx={styles.wrapper}>
           <Sidebar
             ref={nav}
@@ -34,11 +26,6 @@ export const Layout = ({ children }) => {
             onClick={() => setOpen(false)}
           />
           <Container sx={styles.content} data-testid="main-container">
-            <Box sx={styles.menuIcon}>
-              <button sx={styles.menuButton} onClick={handleMenu}>
-                <Menu size={25} />
-              </button>
-            </Box>
             {children}
           </Container>
         </div>

--- a/core/gatsby-theme-docz/src/components/Layout/styles.js
+++ b/core/gatsby-theme-docz/src/components/Layout/styles.js
@@ -1,5 +1,4 @@
 import { media } from '~theme/breakpoints'
-import * as mixins from '~utils/mixins'
 
 export const main = {
   display: 'flex',
@@ -28,20 +27,4 @@ export const content = {
     px: 4,
     pt: 5,
   },
-}
-
-export const menuIcon = {
-  position: 'absolute',
-  top: 15,
-  left: 30,
-  display: 'none',
-  [media.tablet]: {
-    display: 'block',
-  },
-}
-
-export const menuButton = {
-  ...mixins.ghostButton,
-  color: 'header.text',
-  opacity: 0.5,
 }

--- a/core/gatsby-theme-docz/src/components/NavGroup/index.js
+++ b/core/gatsby-theme-docz/src/components/NavGroup/index.js
@@ -4,17 +4,18 @@ import React from 'react'
 
 import * as styles from './styles'
 import { NavLink } from '../NavLink'
-import { ChevronDown, ChevronUp } from '../Icons'
+import { ChevronDown } from '../Icons'
 
 export const NavGroup = ({ item }) => {
   const { menu } = item
   const [subheadingsVisible, setShowsubheadings] = React.useState(true)
   const toggleSubheadings = () => setShowsubheadings(!subheadingsVisible)
-  const exandCollapseIcon = subheadingsVisible ? <ChevronUp /> : <ChevronDown />
+
   return (
     <div sx={styles.wrapper} data-testid="nav-group">
       <div sx={styles.title} onClick={toggleSubheadings}>
-        {item.name} {exandCollapseIcon}
+        {item.name}
+        <ChevronDown sx={styles.chevron({ active: subheadingsVisible })} />
       </div>
       <div sx={styles.sublinkWrapper} data-testid="nav-group-links">
         {menu &&

--- a/core/gatsby-theme-docz/src/components/NavGroup/styles.js
+++ b/core/gatsby-theme-docz/src/components/NavGroup/styles.js
@@ -16,3 +16,12 @@ export const title = {
   justifyContent: 'space-between',
   alignItems: 'center',
 }
+
+export const chevron = ({ active }) => ({
+  ml: 1,
+  flexShrink: 0,
+  alignSelf: 'baseline',
+  transform: `rotateX(${active ? 180 : 0}deg)`,
+  transformOrigin: 'center',
+  transition: 'transform .3s ease-in-out',
+})

--- a/core/gatsby-theme-docz/src/components/Sidebar/styles.js
+++ b/core/gatsby-theme-docz/src/components/Sidebar/styles.js
@@ -9,7 +9,7 @@ export const global = {
 export const overlay = ({ open }) => ({
   zIndex: 999,
   position: 'fixed',
-  top: 104,
+  top: 88,
   right: 0,
   bottom: 0,
   left: 0,
@@ -37,7 +37,7 @@ export const wrapper = ({ open }) => ({
     zIndex: 9999,
     display: 'block',
     position: 'fixed',
-    top: 104,
+    top: 88,
     left: 0,
     bottom: 0,
     width: 256,


### PR DESCRIPTION
Resolves #1112 

- Moves the menu icon from sidebar to header
- Fixes gap between header and nav/layer on tablet
- Smaller tweaks to NavGroup chevron