### PR TITLE
(docz-core) handle props on windows

### DIFF
--- a/core/docz-core/__fixtures__/Alert/Alert.mdx
+++ b/core/docz-core/__fixtures__/Alert/Alert.mdx
@@ -1,0 +1,28 @@
+---
+name: Alert
+menu: Components
+---
+
+import { Playground, Props } from 'docz'
+import { Alert } from './Alert'
+
+# Alert
+
+## Properties
+
+<Props of={Alert} />
+
+## Basic usage
+
+<Playground>
+  <Alert>Some message</Alert>
+</Playground>
+
+## Using different kinds
+
+<Playground>
+  <Alert kind="info">Some message</Alert>
+  <Alert kind="positive">Some message</Alert>
+  <Alert kind="negative">Some message</Alert>
+  <Alert kind="warning">Some message</Alert>
+</Playground>

--- a/core/docz-core/__fixtures__/Alert/Alert.tsx
+++ b/core/docz-core/__fixtures__/Alert/Alert.tsx
@@ -1,4 +1,5 @@
 import React, { SFC } from 'react'
+import styled from '@emotion/styled'
 
 export type Kind = 'info' | 'positive' | 'negative' | 'warning'
 export type KindMap = Record<Kind, string>
@@ -18,7 +19,14 @@ export interface AlertProps {
   kind: 'info' | 'positive' | 'negative' | 'warning'
 }
 
+const AlertStyled = styled('div')<AlertProps>`
+  padding: 15px 20px;
+  background: white;
+  border-radius: 3px;
+  color: white;
+  background: ${({ kind = 'info' }) => kinds[kind]};
+`
+
 export const Alert: SFC<AlertProps> = ({ kind, ...props }) => (
-  //@ts-ignore
-  <div className="alert"> </div>
+  <AlertStyled {...props} kind={kind} />
 )

--- a/core/docz-core/__fixtures__/Label.jsx
+++ b/core/docz-core/__fixtures__/Label.jsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import t from 'prop-types'
+
+const Label = ({ text, ...props }) => (
+  <div className="label" {...props}>
+    {text}
+  </div>
+)
+
+Label.propTypes = {
+  /** A nice string */
+  text: t.string,
+}
+
+export default Label

--- a/core/docz-core/__fixtures__/Label.tsx
+++ b/core/docz-core/__fixtures__/Label.tsx
@@ -1,0 +1,17 @@
+import React, { SFC } from 'react'
+
+export interface LabelProps {
+  /**
+   * Set this to do the thing
+   * @default info
+   */
+  text: string
+}
+
+const Label: SFC<LabelProps> = ({ text, ...props }) => (
+  <div className="label" {...props}>
+    {text}
+  </div>
+)
+
+export default Label

--- a/core/docz-core/__tests__/entries.test.ts
+++ b/core/docz-core/__tests__/entries.test.ts
@@ -1,0 +1,10 @@
+import { Entries } from '../src/lib/Entries'
+import { getTestConfig } from './utils'
+
+describe('Entries', () => {
+  test('get entries', async () => {
+    const config = getTestConfig()
+    const entries = new Entries(config)
+    expect(entries).toBeTruthy()
+  })
+})

--- a/core/docz-core/__tests__/entries.test.ts
+++ b/core/docz-core/__tests__/entries.test.ts
@@ -1,5 +1,5 @@
 import { Entries } from '../src/lib/Entries'
-import { getTestConfig } from './utils'
+import { getTestConfig } from '../src/test-utils'
 
 describe('Entries', () => {
   test('get entries', async () => {

--- a/core/docz-core/__tests__/props.test.ts
+++ b/core/docz-core/__tests__/props.test.ts
@@ -1,11 +1,13 @@
 import { getBaseConfig } from '../src/config/docz'
 import * as paths from '../src/config/paths'
+import * as fs from 'fs-extra'
 import { setArgs } from '../src/config/argv'
 import { getPattern, initial } from '../src/states/props'
 import { Params } from '../src/lib/DataServer'
+import yargs from 'yargs'
 
 const mockedParams = (): Params => {
-  let data = {}
+  let data: any = {}
   return {
     getState: () => data,
     setState: (key: string, value: string) => (data[key] = value),
@@ -13,19 +15,26 @@ const mockedParams = (): Params => {
 }
 
 const mockedArgv = () => {
-  const yargs = {
+  const yargsArgs: any = {
     argv: {},
     option: jest.fn().mockImplementation((key, value) => {
       yargs.argv[value.alias ? value.alias : key] = value.default
       return yargs
     }),
   }
-  const { argv } = setArgs(yargs)
+  const { argv } = setArgs(yargsArgs)
   return argv
 }
 
 describe('props', () => {
-  it('should set props', async () => {
+  const propsCache = '../.docz/.cache/propsParser.json'
+  afterEach(() => {
+    if (fs.existsSync(propsCache)) {
+      fs.removeSync('../.docz/.cache')
+    }
+  })
+
+  it('should set props from typescript files', async () => {
     const argv = mockedArgv()
     //@ts-ignore
     const config = { ...getBaseConfig(argv), paths, typescript: true }
@@ -33,6 +42,6 @@ describe('props', () => {
     const data = initial(config, pattern)
     const params = mockedParams()
     await data(params)
-    expect(params.getState()).toBeTruthy()
+    expect(params.getState().props.length).toBeGreaterThan(0)
   })
 })

--- a/core/docz-core/__tests__/props.test.ts
+++ b/core/docz-core/__tests__/props.test.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs-extra'
 import { getPattern, initial } from '../src/states/props'
 import { readCacheFile } from '../src/utils/docgen/typescript'
-import { getTestConfig, mockedParams } from './utils'
+import { getTestConfig, mockedParams } from '../src/test-utils'
 
 describe('props', () => {
   beforeEach(() => {
@@ -67,7 +67,7 @@ describe('props', () => {
   })
 
   describe('cache', () => {
-    test('should have empty cache on start', () => {
+    test('should have empty cache on start', async () => {
       const cache = readCacheFile()
       expect(cache).toBeNull()
     })

--- a/core/docz-core/__tests__/props.test.ts
+++ b/core/docz-core/__tests__/props.test.ts
@@ -1,0 +1,38 @@
+import { getBaseConfig } from '../src/config/docz'
+import * as paths from '../src/config/paths'
+import { setArgs } from '../src/config/argv'
+import { getPattern, initial } from '../src/states/props'
+import { Params } from '../src/lib/DataServer'
+
+const mockedParams = (): Params => {
+  let data = {}
+  return {
+    getState: () => data,
+    setState: (key: string, value: string) => (data[key] = value),
+  }
+}
+
+const mockedArgv = () => {
+  const yargs = {
+    argv: {},
+    option: jest.fn().mockImplementation((key, value) => {
+      yargs.argv[value.alias ? value.alias : key] = value.default
+      return yargs
+    }),
+  }
+  const { argv } = setArgs(yargs)
+  return argv
+}
+
+describe('props', () => {
+  it('should set props', async () => {
+    const argv = mockedArgv()
+    //@ts-ignore
+    const config = { ...getBaseConfig(argv), paths, typescript: true }
+    const pattern = getPattern(config)
+    const data = initial(config, pattern)
+    const params = mockedParams()
+    await data(params)
+    expect(params.getState()).toBeTruthy()
+  })
+})

--- a/core/docz-core/__tests__/utils.ts
+++ b/core/docz-core/__tests__/utils.ts
@@ -1,0 +1,37 @@
+import * as paths from '../src/config/paths'
+import yargs from 'yargs'
+import { setArgs, Config } from '../src/config/argv'
+import { Params } from '../src/lib/DataServer'
+import { getBaseConfig } from '../src/config/docz'
+
+export const mockedParams = (): Params => {
+  let data: any = {}
+  return {
+    getState: () => data,
+    setState: (key: string, value: string) => (data[key] = value),
+  }
+}
+
+export const mockedArgv = () => {
+  const yargsArgs: any = {
+    argv: {},
+    option: jest.fn().mockImplementation((key, value) => {
+      yargs.argv[value.alias ? value.alias : key] = value.default
+      return yargs
+    }),
+  }
+  const { argv } = setArgs(yargsArgs)
+  return argv
+}
+
+export const getTestConfig = (overrides?: Partial<Config>): Config => {
+  const argv = mockedArgv()
+  return {
+    //@ts-ignore
+    ...getBaseConfig(argv),
+    paths,
+    typescript: true,
+    src: './__fixtures__',
+    ...overrides,
+  }
+}

--- a/core/docz-core/src/config/docz.ts
+++ b/core/docz-core/src/config/docz.ts
@@ -26,9 +26,7 @@ export const doczRcBaseConfig = {
     /license.md/i,
   ],
   filterComponents: (files: string[]) =>
-    files.filter(filepath =>
-      /\/[(a-z)(A-Z)]\w*\.(js|jsx|ts|tsx)$/.test(filepath)
-    ),
+    files.filter(filepath => /\/[A-Z]\w*\.(js|jsx|ts|tsx)$/.test(filepath)),
 }
 
 export const getBaseConfig = (

--- a/core/docz-core/src/config/docz.ts
+++ b/core/docz-core/src/config/docz.ts
@@ -26,7 +26,9 @@ export const doczRcBaseConfig = {
     /license.md/i,
   ],
   filterComponents: (files: string[]) =>
-    files.filter(filepath => /\/[A-Z]\w*\.(js|jsx|ts|tsx)$/.test(filepath)),
+    files.filter(filepath =>
+      /\/[(a-z)(A-Z)]\w*\.(js|jsx|ts|tsx)$/.test(filepath)
+    ),
 }
 
 export const getBaseConfig = (

--- a/core/docz-core/src/states/props.ts
+++ b/core/docz-core/src/states/props.ts
@@ -9,7 +9,7 @@ import { Config } from '../config/argv'
 import { docgen } from '../utils/docgen'
 import { WATCH_IGNORE } from './config'
 
-const getPattern = (config: Config) => {
+export const getPattern = (config: Config) => {
   const {
     ignore,
     src: source,
@@ -35,7 +35,9 @@ const getPattern = (config: Config) => {
 const removeFilepath = (items: any[], filepath: string) =>
   items.filter((item: any) => item.key !== filepath)
 
-const initial = (config: Config, pattern: string[]) => async (p: Params) => {
+export const initial = (config: Config, pattern: string[]) => async (
+  p: Params
+) => {
   const { filterComponents } = config
   const cwd = paths.getRootDir(config)
   const files = await fastglob(pattern, { cwd })

--- a/core/docz-core/src/test-utils/index.ts
+++ b/core/docz-core/src/test-utils/index.ts
@@ -1,8 +1,8 @@
-import * as paths from '../src/config/paths'
+import * as paths from '../config/paths'
 import yargs from 'yargs'
-import { setArgs, Config } from '../src/config/argv'
-import { Params } from '../src/lib/DataServer'
-import { getBaseConfig } from '../src/config/docz'
+import { setArgs, Config } from '../config/argv'
+import { Params } from '../lib/DataServer'
+import { getBaseConfig } from '../config/docz'
 
 export const mockedParams = (): Params => {
   let data: any = {}
@@ -15,6 +15,7 @@ export const mockedParams = (): Params => {
 export const mockedArgv = () => {
   const yargsArgs: any = {
     argv: {},
+    //@ts-ignore
     option: jest.fn().mockImplementation((key, value) => {
       yargs.argv[value.alias ? value.alias : key] = value.default
       return yargs

--- a/core/docz-core/src/utils/docgen/index.ts
+++ b/core/docz-core/src/utils/docgen/index.ts
@@ -4,9 +4,10 @@ import * as paths from '../../config/paths'
 import { Config } from '../../config/argv'
 import { jsParser } from './javascript'
 import { tsParser } from './typescript'
+import { normalize } from 'path'
 
 export const unixPath = (src: string): string => {
-  return src.replace(/\\/g, '/')
+  return normalize(src).replace(/\\/g, '/')
 }
 
 export const docgen = async (files: string[], config: Config) => {

--- a/core/docz-core/src/utils/docgen/index.ts
+++ b/core/docz-core/src/utils/docgen/index.ts
@@ -5,6 +5,10 @@ import { Config } from '../../config/argv'
 import { jsParser } from './javascript'
 import { tsParser } from './typescript'
 
+export const unixPath = (src: string): string => {
+  return src.replace(/\\/g, '/')
+}
+
 export const docgen = async (files: string[], config: Config) => {
   const cwd = paths.getRootDir(config)
   const tsconfig = await findUp('tsconfig.json', { cwd })

--- a/core/docz-core/src/utils/docgen/javascript.ts
+++ b/core/docz-core/src/utils/docgen/javascript.ts
@@ -7,6 +7,7 @@ import * as reactDocgen from 'react-docgen'
 
 import { Config } from '../../config/argv'
 import { getRootDir } from '../../config/paths'
+import { unixPath } from '.'
 
 const throwError = (err: any) => {
   logger.fatal(`Error parsing static types`)
@@ -29,7 +30,7 @@ export const jsParser = (files: string[], config: Config) => {
     try {
       const code = fs.readFileSync(fullpath, { encoding: 'utf-8' })
       const props = reactDocgen.parse(code, resolver, handlers)
-      return { key: path.normalize(filepath), value: props }
+      return { key: unixPath(filepath), value: props }
     } catch (err) {
       if (config.debug) throwError(err)
       return null

--- a/core/docz-core/src/utils/docgen/javascript.ts
+++ b/core/docz-core/src/utils/docgen/javascript.ts
@@ -3,7 +3,7 @@ import * as path from 'path'
 import logger from 'signale'
 import externalProptypesHandler from './externalProptypesHandler'
 import actualNameHandler from 'react-docgen-actual-name-handler'
-import reactDocgen from 'react-docgen'
+import * as reactDocgen from 'react-docgen'
 
 import { Config } from '../../config/argv'
 import { getRootDir } from '../../config/paths'

--- a/core/docz-core/src/utils/docgen/typescript.ts
+++ b/core/docz-core/src/utils/docgen/typescript.ts
@@ -8,6 +8,7 @@ import ts from 'typescript'
 
 import { Config } from '../../config/argv'
 import * as paths from '../../config/paths'
+import { unixPath } from '.'
 
 export interface TSFile {
   text?: string
@@ -64,7 +65,7 @@ function getPropsOnCache(): any {
   }
 
   return Object.entries(cache).map(([key, value]) => ({
-    key,
+    key: unixPath(key),
     value: _.get('props', value),
   }))
 }
@@ -195,7 +196,7 @@ const parseFiles = (files: string[], config: Config, tsconfig: string) => {
   }
 
   return files.map(filepath => ({
-    key: path.normalize(filepath),
+    key: unixPath(filepath),
     value: parser.parseWithProgramProvider(filepath, programProvider),
   }))
 }

--- a/core/docz-core/src/utils/docgen/typescript.ts
+++ b/core/docz-core/src/utils/docgen/typescript.ts
@@ -27,7 +27,8 @@ const digest = (str: string) =>
     .digest('hex')
 
 const cacheFilepath = path.join(paths.cache, 'propsParser.json')
-const readCacheFile = () => fs.readJSONSync(cacheFilepath, { throws: false })
+export const readCacheFile = () =>
+  fs.readJSONSync(cacheFilepath, { throws: false })
 
 function checkFilesOnCache(files: string[], config: Config): string[] {
   const cache = readCacheFile()
@@ -46,10 +47,9 @@ function writePropsOnCache(items: PropItem[], config: Config): void {
   const cache = readCacheFile()
   const root = paths.getRootDir(config)
   const newCache = items.reduce((obj, { key: filepath, value }) => {
-    const normalized = path.normalize(filepath)
-    const fullpath = path.resolve(root, normalized)
+    const fullpath = path.resolve(root, path.normalize(filepath))
     const hash = digest(fs.readFileSync(fullpath, 'utf-8'))
-    return { ...obj, [normalized]: { hash, props: value } }
+    return { ...obj, [unixPath(filepath)]: { hash, props: value } }
   }, {})
 
   fs.outputJSONSync(cacheFilepath, { ...cache, ...newCache })
@@ -119,7 +119,7 @@ function loadFiles(filesToLoad: string[], config: Config): void {
     const normalized = path.normalize(filepath)
     const fullpath = path.resolve(root, normalized)
     const found = filesMap.get(normalized)
-    filesMap.set(normalized, {
+    filesMap.set(unixPath(filepath), {
       text: fs.readFileSync(fullpath, 'utf-8'),
       version: found ? found.version + 1 : 0,
     })

--- a/core/docz-core/src/utils/docgen/typescript.ts
+++ b/core/docz-core/src/utils/docgen/typescript.ts
@@ -3,7 +3,7 @@ import * as path from 'path'
 import * as crypto from 'crypto'
 import * as _ from 'lodash/fp'
 import * as logger from 'signale'
-import reactDocgenTs from 'react-docgen-typescript'
+import * as reactDocgenTs from 'react-docgen-typescript'
 import ts from 'typescript'
 
 import { Config } from '../../config/argv'

--- a/core/docz-core/src/utils/docgen/typescript.ts
+++ b/core/docz-core/src/utils/docgen/typescript.ts
@@ -119,7 +119,7 @@ function loadFiles(filesToLoad: string[], config: Config): void {
     const normalized = path.normalize(filepath)
     const fullpath = path.resolve(root, normalized)
     const found = filesMap.get(normalized)
-    filesMap.set(unixPath(filepath), {
+    filesMap.set(normalized, {
       text: fs.readFileSync(fullpath, 'utf-8'),
       version: found ? found.version + 1 : 0,
     })

--- a/other-packages/e2e-tests/__tests__/test.ts
+++ b/other-packages/e2e-tests/__tests__/test.ts
@@ -29,3 +29,10 @@ test('Renders the right layout and nav', async t => {
   const liveEditor = await getByTestId('live-editor')
   await t.expect(liveEditor.count).eql(2)
 })
+
+test('Render props', async t => {
+  await t.navigateTo('/src-components-alert')
+  const prop = await getByTestId('prop')
+  await t.expect(prop.exists).eql(true)
+  await t.expect(prop.count).eql(1)
+})

--- a/other-packages/e2e-tests/index.js
+++ b/other-packages/e2e-tests/index.js
@@ -42,6 +42,10 @@ const examples = {
       'examples/monorepo-package/packages/basic'
     ),
   },
+  typescript: {
+    path: path.join(rootPath, 'examples/typescript'),
+    tmp: path.join(tmpPath, 'examples/typescript'),
+  },
 }
 
 const startLocalRegistry = async () => {


### PR DESCRIPTION
### Description

Draft for fix for finding and parsing files on Windows (#1091 )

Not tested more than the supplied test that I am getting back props when setting state. Primarily [fastglob needs forward slashed](https://github.com/mrmlnc/fast-glob#how-to-write-patterns-on-windows) which it was not getting.

* Is there occasions where forward slashes should not be used in the state of the application, when is it a problem?