### PR TITLE
Remove npm as dependency [wip]

### DIFF
--- a/core/docz-core/.lintstagedrc
+++ b/core/docz-core/.lintstagedrc
@@ -1,3 +1,3 @@
 {
-  "*.{ts,tsx}": ["yarn fix", "git add"]
+  "*.{ts,tsx}": ["npm run fix", "git add"]
 }

--- a/core/docz-core/nodemon.json
+++ b/core/docz-core/nodemon.json
@@ -1,6 +1,6 @@
 {
   "ignore": ["dist/"],
   "//verbose": true,
-  "exec": "yarn build && node bin/index.js init",
+  "exec": "npm run build && node bin/index.js init",
   "ext": "js,ts,json"
 }

--- a/core/docz-core/package.json
+++ b/core/docz-core/package.json
@@ -12,13 +12,13 @@
     "README.md"
   ],
   "scripts": {
-    "build": "yarn cross-env NODE_ENV=production rollup -c",
-    "dev": "yarn cross-env NODE_ENV=development yarn build -w",
-    "fix": "yarn lint --fix",
-    "lint": "yarn eslint . --ext .ts,.tsx",
+    "build": "cross-env NODE_ENV=production npx rollup -c",
+    "dev": "cross-env NODE_ENV=development npm run build -- -w",
+    "fix": "npm run lint -- --fix",
+    "lint": "npx eslint . --ext .ts,.tsx",
     "precommit": "lint-staged",
-    "prepare": "yarn build",
-    "test": "yarn jest"
+    "prepare": "npm run build",
+    "test": "npx jest"
   },
   "dependencies": {
     "@sindresorhus/slugify": "^0.9.1",

--- a/core/docz-core/src/bundler/build.ts
+++ b/core/docz-core/src/bundler/build.ts
@@ -9,15 +9,15 @@ import { ensureFiles } from './machine/actions'
 
 export const build: BuildFn = async (config, dist) => {
   const publicDir = path.join(paths.docz, 'public')
-  const cliArgs = ['build']
+  const cliArgs = ['run', 'build']
 
   if (typeof config.base === 'string' && config.base.length) {
     // Append gatsby option `prefixPaths`to CLI args
     // https://www.gatsbyjs.org/docs/path-prefix/
-    cliArgs.push('--prefixPaths')
+    cliArgs.push('--', '--prefixPaths')
   }
   ensureFiles({ args: config })
   sh.cd(paths.docz)
-  spawn.sync('yarn', cliArgs, { stdio: 'inherit' })
+  spawn.sync('npm', cliArgs, { stdio: 'inherit' })
   await fs.copy(publicDir, dist)
 }

--- a/core/docz-core/src/bundler/machine/services/exec-dev-command.ts
+++ b/core/docz-core/src/bundler/machine/services/exec-dev-command.ts
@@ -7,7 +7,9 @@ import * as paths from '../../../config/paths'
 
 export const execDevCommand = async ({ args }: ServerMachineCtx) => {
   sh.cd(paths.docz)
-  spawn('yarn', ['dev', '--port', `${args.port}`], { stdio: 'inherit' })
+  spawn('npm', ['run', 'dev', '--', '--port', `${args.port}`], {
+    stdio: 'inherit',
+  })
   const url = `http://${args.host}:${args.port}`
   console.log()
   console.log('Building app')

--- a/core/docz-core/src/commands/serve.ts
+++ b/core/docz-core/src/commands/serve.ts
@@ -7,14 +7,14 @@ import { parseConfig } from '../config/docz'
 
 export const serve = async (args: Arguments<any>) => {
   const config = await parseConfig(args)
-  const cliArgs = ['serve']
+  const cliArgs = ['run', 'serve']
 
   if (typeof config.base === 'string' && config.base.length) {
     // Append gatsby option `prefixPaths`to CLI args
     // https://www.gatsbyjs.org/docs/path-prefix/
-    cliArgs.push('--prefixPaths')
+    cliArgs.push('--', '--prefixPaths')
   }
 
   sh.cd(paths.docz)
-  spawn.sync('yarn', cliArgs, { stdio: 'inherit' })
+  spawn.sync('npm', cliArgs, { stdio: 'inherit' })
 }

--- a/core/docz/.lintstagedrc
+++ b/core/docz/.lintstagedrc
@@ -1,3 +1,3 @@
 {
-  "*.{ts,tsx}": ["yarn fix", "git add"]
+  "*.{ts,tsx}": ["npm run fix", "git add"]
 }

--- a/core/docz/package.json
+++ b/core/docz/package.json
@@ -16,9 +16,9 @@
     "README.md"
   ],
   "scripts": {
-    "dev": "cross-env NODE_ENV=development yarn build -w",
-    "build": "cross-env NODE_ENV=production rollup -c",
-    "fix": "yarn lint --fix",
+    "dev": "cross-env NODE_ENV=development npm run build -- -w",
+    "build": "cross-env NODE_ENV=production npx rollup -c",
+    "fix": "npm run lint -- --fix",
     "lint": "eslint . --ext .ts,.tsx",
     "precommit": "lint-staged"
   },

--- a/dev-env/basic/dev.js
+++ b/dev-env/basic/dev.js
@@ -38,19 +38,16 @@ export default timestamp
 }
 
 const getDestinationPath = (name, outputDir = '') => {
-  return path.join(
-    __dirname,
-    `node_modules/${name}/${outputDir}`
-  )
+  return path.join(__dirname, `node_modules/${name}/${outputDir}`)
 }
 
 const watchPackage = async (name, outputDir) => {
   const sourcePath = path.join(rootPath, `core/${name}/${outputDir}`)
   const destinationPath = getDestinationPath(name, outputDir)
   const sourceRootPath = path.join(rootPath, `core/${name}/`)
-  const dev = runCommand(`yarn run dev`, { cwd: sourceRootPath })
+  const dev = runCommand(`npm run dev`, { cwd: sourceRootPath })
   try {
-    await runCommand(`yarn run build`, { cwd: sourceRootPath })
+    await runCommand(`npm run build`, { cwd: sourceRootPath })
   } catch (err) {
     console.log(
       `Failed to build ${name}, before running dev. This is not necessarily an issue : ${err.message}`
@@ -62,8 +59,12 @@ const watchPackage = async (name, outputDir) => {
      we need to watch the source code without node_modules */
   if (name === 'gatsby-theme-docz') {
     fileWatchers.push(cpx.watch(`${sourcePath}/*`, getDestinationPath(name)))
-    fileWatchers.push(cpx.watch(`${sourcePath}/src/**/*`, getDestinationPath(name, 'src')))
-    fileWatchers.push(cpx.watch(`${sourcePath}/lib/**/*`, getDestinationPath(name, 'lib')))
+    fileWatchers.push(
+      cpx.watch(`${sourcePath}/src/**/*`, getDestinationPath(name, 'src'))
+    )
+    fileWatchers.push(
+      cpx.watch(`${sourcePath}/lib/**/*`, getDestinationPath(name, 'lib'))
+    )
   } else {
     const sync = cpx.watch(`${sourcePath}/**/*`, destinationPath)
     fileWatchers.push(sync)


### PR DESCRIPTION
### Description

Working on https://github.com/doczjs/docz/issues/959.

This is currently in the stage of working with installed dependencies using yarn. But when installing via npm it still falls short. Maybe need some pre-hook for installing

### Review

- [ ] Check the copy
- [ ] ...
- [ ] ...

### Pre-merge checklist

- [ ] ...
- [ ] ...

### Screenshots

| Before | After |
| ------ | ----- |
| Image  | Image |