### PR TITLE
fix(gatsby-theme-docz): round playground borders #1080

### DIFF
--- a/core/gatsby-theme-docz/src/components/Playground/styles.js
+++ b/core/gatsby-theme-docz/src/components/Playground/styles.js
@@ -4,6 +4,7 @@ export const editor = theme => ({
   p: 2,
   border: t => `1px solid ${t.colors.border}`,
   borderRadius: '0 0 4px 4px',
+  overflow: 'hidden',
   background: theme.plain.backgroundColor,
   borderTop: 0,
   fontFamily: 'monospace',


### PR DESCRIPTION
### Description

Removes the tiny overflow on playground (#1080)