### PR TITLE
feat(docz-components): add fullscreen mode

### DIFF
--- a/core/docz-components/src/components/Dialog/index.tsx
+++ b/core/docz-components/src/components/Dialog/index.tsx
@@ -4,6 +4,7 @@ import { createRef, SyntheticEvent } from 'react';
 
 import { useScrollLock, useEscape } from '../../utils/hooks';
 import { Portal } from '../Portal';
+import * as Icons from '../Icons'
 
 import * as styles from './styles';
 
@@ -43,6 +44,9 @@ export const Dialog: React.FC<DialogProps> = props => {
           ref={dialogContentRef}
           onMouseDown={handleClick}
         >
+          <span sx={styles.close} onClick={onClose}>
+            <Icons.Close size={20} />
+          </span>
           {children}
         </div>
       </div>

--- a/core/docz-components/src/components/Dialog/index.tsx
+++ b/core/docz-components/src/components/Dialog/index.tsx
@@ -4,17 +4,19 @@ import { createRef, SyntheticEvent } from 'react';
 
 import { useScrollLock, useEscape } from '../../utils/hooks';
 import { Portal } from '../Portal';
-import * as Icons from '../Icons'
+import * as Icons from '../Icons';
 
 import * as styles from './styles';
 
 interface DialogProps {
   title: string;
   onClose: () => any;
+  width?: string;
+  height?: string;
 }
 
 export const Dialog: React.FC<DialogProps> = props => {
-  const { children, onClose, title } = props;
+  const { children, onClose, title, height = '90%', width = '90%' } = props;
 
   const dialogContentRef = createRef<HTMLDivElement>();
 
@@ -24,10 +26,7 @@ export const Dialog: React.FC<DialogProps> = props => {
 
   const handleClick = (event: SyntheticEvent) => {
     const node = event.target as Node;
-    if (
-      dialogContentRef.current &&
-      dialogContentRef.current.contains(node)
-    ) {
+    if (dialogContentRef.current && dialogContentRef.current.contains(node)) {
       return;
     }
     onClose();
@@ -39,7 +38,7 @@ export const Dialog: React.FC<DialogProps> = props => {
         <div
           aria-label={title}
           role="dialog"
-          sx={styles.content}
+          sx={styles.content(width, height)}
           aria-modal={true}
           ref={dialogContentRef}
           onMouseDown={handleClick}

--- a/core/docz-components/src/components/Dialog/index.tsx
+++ b/core/docz-components/src/components/Dialog/index.tsx
@@ -1,0 +1,53 @@
+/** @jsx jsx */
+import { jsx } from 'theme-ui';
+import { createRef, SyntheticEvent } from 'react';
+
+import { useScrollLock, useEscape } from '../../utils/hooks';
+import { Portal } from '../Portal';
+
+import * as styles from './styles';
+
+interface DialogProps {
+  title: string;
+  onClose: () => any;
+}
+
+export const Dialog: React.FC<DialogProps> = props => {
+  const { children, onClose, title } = props;
+
+  const dialogContentRef = createRef<HTMLDivElement>();
+
+  useScrollLock();
+
+  useEscape(onClose);
+
+  const handleClick = (event: SyntheticEvent) => {
+    const node = event.target as Node;
+    if (
+      dialogContentRef.current &&
+      dialogContentRef.current.contains(node)
+    ) {
+      return;
+    }
+    onClose();
+  };
+
+  return (
+    <Portal>
+      <div sx={styles.overlay} onMouseDown={handleClick}>
+        <div
+          aria-label={title}
+          role="dialog"
+          sx={styles.content}
+          aria-modal={true}
+          ref={dialogContentRef}
+          onMouseDown={handleClick}
+        >
+          {children}
+        </div>
+      </div>
+    </Portal>
+  );
+};
+
+export default Dialog;

--- a/core/docz-components/src/components/Dialog/styles.ts
+++ b/core/docz-components/src/components/Dialog/styles.ts
@@ -8,35 +8,35 @@ export const overlay = {
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
-  zIndex: 9999
-}
+  zIndex: 9999,
+};
 
-export const content = {
+export const content = (width: string, height: string) => ({
   position: 'relative',
-  width: '90%',
-  height: '90%',
+  width,
+  height,
   backgroundColor: '#fff',
   padding: '1rem',
   borderRadius: '0.25rem',
   display: 'flex',
   flexDirection: 'column',
-}
+  alignItems: 'center',
+  justifyContent: 'space-around',
+});
 
 export const close = {
   position: 'absolute',
   top: 2,
   right: 2,
   zIndex: 999,
-  border: '1px solid',
-  borderColor: 'playground.border',
-  backgroundColor: '#fff',
+  backgroundColor: 'background',
   borderRadius: 2,
   height: 20,
   width: 20,
   padding: 0,
   margin: 0,
   cursor: 'pointer',
-  '&:hover' : {
-    backgroundColor: '#f3f3f3'
-  }
-}
+  '&:hover': {
+    backgroundColor: '#f3f3f3',
+  },
+};

--- a/core/docz-components/src/components/Dialog/styles.ts
+++ b/core/docz-components/src/components/Dialog/styles.ts
@@ -1,0 +1,23 @@
+export const overlay = {
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  width: '100vw',
+  height: '100vh',
+  backgroundColor: 'rgba(0, 0, 0, 0.3)',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  zIndex: 9999
+}
+
+export const content = {
+  position: 'relative',
+  width: '90%',
+  height: '90%',
+  backgroundColor: '#fff',
+  padding: '1rem',
+  borderRadius: '0.25rem',
+  display: 'flex',
+  flexDirection: 'column',
+}

--- a/core/docz-components/src/components/Dialog/styles.ts
+++ b/core/docz-components/src/components/Dialog/styles.ts
@@ -21,3 +21,22 @@ export const content = {
   display: 'flex',
   flexDirection: 'column',
 }
+
+export const close = {
+  position: 'absolute',
+  top: 2,
+  right: 2,
+  zIndex: 999,
+  border: '1px solid',
+  borderColor: 'playground.border',
+  backgroundColor: '#fff',
+  borderRadius: 2,
+  height: 20,
+  width: 20,
+  padding: 0,
+  margin: 0,
+  cursor: 'pointer',
+  '&:hover' : {
+    backgroundColor: '#f3f3f3'
+  }
+}

--- a/core/docz-components/src/components/DialogActions/index.tsx
+++ b/core/docz-components/src/components/DialogActions/index.tsx
@@ -1,48 +1,47 @@
-import * as React from 'react'
-import { SFC } from 'react'
-import * as Icons from '../Icons'
+/** @jsx jsx */
+import { jsx } from 'theme-ui';
+import { SFC, FC } from 'react';
+import * as Icons from '../Icons';
+import * as styles from './styles';
 
-const wrapper = {
-  position: 'absolute',
-  top: 2,
-  left: '50%',
-  marginBottom: 1,
-  transform: 'translateX(-50%)' 
+export interface DialogActionsProps {
+  onChangeSize: (width: string, height: string) => void;
 }
 
-const buttons = {
-  display: 'flex',
-  background: '',
-  border: '1px solid white',
-  borderRadius: 2,
-  padding: '3px 5px'
-}
-
-export interface ResizeProps {
-  onChangeSize: (width: string, height: string) => void
-}
-
-export const DialogActions: SFC<ResizeProps> = ({ onChangeSize }) => (
-  <div sx={wrapper}>
-    <div sx={buttons}>
-      <button
+export const DialogActions: SFC<DialogActionsProps> = ({ onChangeSize }) => (
+  <div>
+    <div sx={styles.buttons}>
+      <ActionButton
         onClick={() => onChangeSize('360px', '640px')}
         title="Smartphone"
       >
         <Icons.Smartphone width={20} />
-      </button>
-      <button
+      </ActionButton>
+      <ActionButton
         onClick={() => onChangeSize('768px', '1024px')}
         title="Tablet"
       >
         <Icons.Tablet width={20} />
-      </button>
-      <button
+      </ActionButton>
+      <ActionButton
         onClick={() => onChangeSize('1366px', '1024px')}
         title="Monitor"
       >
         <Icons.Monitor width={20} />
-      </button>
+      </ActionButton>
     </div>
   </div>
-)
+);
+
+export interface ActionButtonProps {
+  onClick: () => void;
+  title: string;
+}
+
+const ActionButton: FC<ActionButtonProps> = ({ onClick, title, children }) => {
+  return (
+    <button sx={styles.actionButton} onClick={onClick} title={title}>
+      {children}
+    </button>
+  );
+};

--- a/core/docz-components/src/components/DialogActions/index.tsx
+++ b/core/docz-components/src/components/DialogActions/index.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react'
+import { SFC } from 'react'
+import * as Icons from '../Icons'
+
+const wrapper = {
+  position: 'absolute',
+  top: 2,
+  left: '50%',
+  marginBottom: 1,
+  transform: 'translateX(-50%)' 
+}
+
+const buttons = {
+  display: 'flex',
+  background: '',
+  border: '1px solid white',
+  borderRadius: 2,
+  padding: '3px 5px'
+}
+
+export interface ResizeProps {
+  onChangeSize: (width: string, height: string) => void
+}
+
+export const DialogActions: SFC<ResizeProps> = ({ onChangeSize }) => (
+  <div sx={wrapper}>
+    <div sx={buttons}>
+      <button
+        onClick={() => onChangeSize('360px', '640px')}
+        title="Smartphone"
+      >
+        <Icons.Smartphone width={20} />
+      </button>
+      <button
+        onClick={() => onChangeSize('768px', '1024px')}
+        title="Tablet"
+      >
+        <Icons.Tablet width={20} />
+      </button>
+      <button
+        onClick={() => onChangeSize('1366px', '1024px')}
+        title="Monitor"
+      >
+        <Icons.Monitor width={20} />
+      </button>
+    </div>
+  </div>
+)

--- a/core/docz-components/src/components/DialogActions/styles.ts
+++ b/core/docz-components/src/components/DialogActions/styles.ts
@@ -1,0 +1,21 @@
+import * as mixins from '../../utils/mixins';
+
+export const buttons = {
+  display: 'flex',
+  margin: 2,
+  borderRadius: 2,
+};
+
+export const actionButton = {
+  ...mixins.ghostButton,
+  display: 'flex',
+  alignItems: 'center',
+  py: 1,
+  p: 2,
+  bg: 'border',
+  color: 'muted',
+  borderRadius: '0 0 3px 3px',
+  '& ~ &': {
+    ml: 1,
+  },
+};

--- a/core/docz-components/src/components/Icons/index.tsx
+++ b/core/docz-components/src/components/Icons/index.tsx
@@ -18,3 +18,13 @@ export { default as Search } from 'react-feather/dist/icons/search';
 export { default as Sun } from 'react-feather/dist/icons/sun';
 //@ts-ignore
 export { default as Maximize } from 'react-feather/dist/icons/maximize-2'
+//@ts-ignore
+export { default as Minimize } from 'react-feather/dist/icons/minimize-2'
+//@ts-ignore
+export { default as Close } from 'react-feather/dist/icons/x'
+//@ts-ignore
+export { default as Smartphone} from 'react-feather/dist/icons/smartphone'
+//@ts-ignore
+export { default as Tablet } from 'react-feather/dist/icons/tablet'
+//@ts-ignore
+export { default as Monitor } from 'react-feather/dist/icons/monitor'

--- a/core/docz-components/src/components/Icons/index.tsx
+++ b/core/docz-components/src/components/Icons/index.tsx
@@ -16,3 +16,5 @@ export { default as Menu } from 'react-feather/dist/icons/menu';
 export { default as Search } from 'react-feather/dist/icons/search';
 //@ts-ignore
 export { default as Sun } from 'react-feather/dist/icons/sun';
+//@ts-ignore
+export { default as Maximize } from 'react-feather/dist/icons/maximize-2'

--- a/core/docz-components/src/components/Playground/LivePreviewWrapper.tsx
+++ b/core/docz-components/src/components/Playground/LivePreviewWrapper.tsx
@@ -9,7 +9,7 @@ const styles = {
     ({
       height,
       display: 'block',
-      minHeight: '100%',
+      minHeight: '95%',
       width: 'calc(100% - 2px)',
       border: (t: Theme) =>
         `1px solid ${get(t, 'colors.playground.border', 'none')}`,

--- a/core/docz-components/src/components/Playground/index.tsx
+++ b/core/docz-components/src/components/Playground/index.tsx
@@ -16,6 +16,7 @@ import { LivePreviewWrapper } from './LivePreviewWrapper';
 import * as styles from './styles';
 import * as Icons from '../Icons';
 import { Dialog } from '../Dialog'
+import { DialogActions } from '../DialogActions'
 
 export type PlaygroundProps = {
   code: string;
@@ -86,6 +87,41 @@ export const Playground = ({
       setWidth(ref.style.width);
     },
   };
+
+  const buttons = (
+    <div sx={styles.buttons}>
+    <button sx={styles.button} onClick={() => copy(code)}>
+      <Icons.Clipboard size={14} />
+    </button>
+    <button sx={styles.button} onClick={toggleCode}>
+      <Icons.Code size={14} />
+    </button>
+    <button sx={styles.button} onClick={toggleFullscreen}>
+      {showFullscreen
+        ? <Icons.Minimize size={14} />
+        : <Icons.Maximize size={14} />
+      }
+    </button>
+  </div>
+  )
+  
+  const preview = (
+    <LivePreviewWrapper showingCode={showingCode}>
+      {showLivePreview && (
+        <LivePreview sx={styles.preview} data-testid="live-preview" />
+      )}
+    </LivePreviewWrapper>
+  )
+
+  const error = showLiveError && (
+    <LiveError sx={styles.error} data-testid="live-error" />
+  )
+
+  const editor = showingCode && (
+    <div sx={styles.editor(theme)}>
+      <LiveEditor data-testid="live-editor" />
+    </div>
+  )
   
   return (
     <Resizable {...resizableProps} data-testid="playground">
@@ -97,52 +133,24 @@ export const Playground = ({
         theme={theme}
       >
         <div sx={styles.previewWrapper}>
-          <LivePreviewWrapper showingCode={showingCode}>
-            {showLivePreview && (
-              <LivePreview sx={styles.preview} data-testid="live-preview" />
-            )}
-          </LivePreviewWrapper>
-          <div sx={styles.buttons}>
-            <button sx={styles.button} onClick={() => copy(code)}>
-              <Icons.Clipboard size={14} />
-            </button>
-            <button sx={styles.button} onClick={toggleCode}>
-              <Icons.Code size={14} />
-            </button>
-            <button sx={styles.button} onClick={toggleFullscreen}>
-              <Icons.Maximize size={14} />
-            </button>
-          </div>
+          {preview}
+          {buttons}
         </div>
-        {showLiveError && (
-          <LiveError sx={styles.error} data-testid="live-error" />
-        )}
-        {showingCode && (
-          <div sx={styles.editor(theme)}>
-            <LiveEditor data-testid="live-editor" />
-          </div>
-        )}
+        {error}
+        {editor}
         {showFullscreen &&
           <Dialog
             title="Live Preview"
             onClose={toggleFullscreen}
             data-testid="livepreview-fullscreen"
           >
-            <div sx={styles.previewWrapper}>
-              <LivePreviewWrapper showingCode={showingCode}>
-                {showLivePreview && (
-                  <LivePreview sx={styles.preview} data-testid="live-preview" />
-                )}
-              </LivePreviewWrapper>
-              {showLiveError && (
-                <LiveError sx={styles.error} data-testid="live-error" />
-              )}
-              {showingCode && (
-                <div sx={styles.editor(theme)}>
-                  <LiveEditor data-testid="live-editor" />
-                </div>
-              )}
+            <DialogActions onChangeSize={() =>{}} />
+            <div sx={styles.dialogPreviewWrapper(showingCode)}>
+              {preview}
+              {buttons}
             </div>
+            {error}
+            {editor}
           </Dialog>}
       </LiveProvider>
     </Resizable>

--- a/core/docz-components/src/components/Playground/index.tsx
+++ b/core/docz-components/src/components/Playground/index.tsx
@@ -15,6 +15,7 @@ import { usePrismTheme } from '../../utils/theme';
 import { LivePreviewWrapper } from './LivePreviewWrapper';
 import * as styles from './styles';
 import * as Icons from '../Icons';
+import { Dialog } from '../Dialog'
 
 export type PlaygroundProps = {
   code: string;
@@ -45,16 +46,21 @@ export const Playground = ({
   const theme = usePrismTheme();
   const [showingCode, setShowingCode] = useState(() => showPlaygroundEditor);
   const [width, setWidth] = useState(() => '100%');
+  const [showFullscreen, setShowFullscreen] = useState<boolean>(() => false)
 
   const transformCode = (codeToTransform: string) => {
     if (codeToTransform.startsWith('()') || codeToTransform.startsWith('class'))
       return codeToTransform;
     return `<React.Fragment>${codeToTransform}</React.Fragment>`;
-  };
+  }
 
   const toggleCode = () => {
     setShowingCode(s => !s);
-  };
+  }
+
+  const toggleFullscreen = () => {
+    setShowFullscreen((f) => !f)
+  }
 
   const resizableProps = {
     minWidth: 260,
@@ -80,6 +86,7 @@ export const Playground = ({
       setWidth(ref.style.width);
     },
   };
+  
   return (
     <Resizable {...resizableProps} data-testid="playground">
       <LiveProvider
@@ -97,10 +104,13 @@ export const Playground = ({
           </LivePreviewWrapper>
           <div sx={styles.buttons}>
             <button sx={styles.button} onClick={() => copy(code)}>
-              <Icons.Clipboard size={12} />
+              <Icons.Clipboard size={14} />
             </button>
             <button sx={styles.button} onClick={toggleCode}>
-              <Icons.Code size={12} />
+              <Icons.Code size={14} />
+            </button>
+            <button sx={styles.button} onClick={toggleFullscreen}>
+              <Icons.Maximize size={14} />
             </button>
           </div>
         </div>
@@ -112,6 +122,28 @@ export const Playground = ({
             <LiveEditor data-testid="live-editor" />
           </div>
         )}
+        {showFullscreen &&
+          <Dialog
+            title="Live Preview"
+            onClose={toggleFullscreen}
+            data-testid="livepreview-fullscreen"
+          >
+            <div sx={styles.previewWrapper}>
+              <LivePreviewWrapper showingCode={showingCode}>
+                {showLivePreview && (
+                  <LivePreview sx={styles.preview} data-testid="live-preview" />
+                )}
+              </LivePreviewWrapper>
+              {showLiveError && (
+                <LiveError sx={styles.error} data-testid="live-error" />
+              )}
+              {showingCode && (
+                <div sx={styles.editor(theme)}>
+                  <LiveEditor data-testid="live-editor" />
+                </div>
+              )}
+            </div>
+          </Dialog>}
       </LiveProvider>
     </Resizable>
   );

--- a/core/docz-components/src/components/Playground/index.tsx
+++ b/core/docz-components/src/components/Playground/index.tsx
@@ -15,8 +15,8 @@ import { usePrismTheme } from '../../utils/theme';
 import { LivePreviewWrapper } from './LivePreviewWrapper';
 import * as styles from './styles';
 import * as Icons from '../Icons';
-import { Dialog } from '../Dialog'
-import { DialogActions } from '../DialogActions'
+import { Dialog } from '../Dialog';
+import { DialogActions } from '../DialogActions';
 
 export type PlaygroundProps = {
   code: string;
@@ -47,21 +47,26 @@ export const Playground = ({
   const theme = usePrismTheme();
   const [showingCode, setShowingCode] = useState(() => showPlaygroundEditor);
   const [width, setWidth] = useState(() => '100%');
-  const [showFullscreen, setShowFullscreen] = useState<boolean>(() => false)
+  const [dialogWidth, setDialogWidth] = useState<string>(() => '90%');
+  const [showFullscreen, setShowFullscreen] = useState<boolean>(() => false);
 
   const transformCode = (codeToTransform: string) => {
     if (codeToTransform.startsWith('()') || codeToTransform.startsWith('class'))
       return codeToTransform;
     return `<React.Fragment>${codeToTransform}</React.Fragment>`;
-  }
+  };
 
   const toggleCode = () => {
     setShowingCode(s => !s);
-  }
+  };
 
   const toggleFullscreen = () => {
-    setShowFullscreen((f) => !f)
-  }
+    setShowFullscreen(f => !f);
+  };
+
+  const onChangeSize = (width: string) => {
+    setDialogWidth(_w => width);
+  };
 
   const resizableProps = {
     minWidth: 260,
@@ -90,39 +95,40 @@ export const Playground = ({
 
   const buttons = (
     <div sx={styles.buttons}>
-    <button sx={styles.button} onClick={() => copy(code)}>
-      <Icons.Clipboard size={14} />
-    </button>
-    <button sx={styles.button} onClick={toggleCode}>
-      <Icons.Code size={14} />
-    </button>
-    <button sx={styles.button} onClick={toggleFullscreen}>
-      {showFullscreen
-        ? <Icons.Minimize size={14} />
-        : <Icons.Maximize size={14} />
-      }
-    </button>
-  </div>
-  )
-  
+      <button sx={styles.button} onClick={() => copy(code)}>
+        <Icons.Clipboard size={14} />
+      </button>
+      <button sx={styles.button} onClick={toggleCode}>
+        <Icons.Code size={14} />
+      </button>
+      <button sx={styles.button} onClick={toggleFullscreen}>
+        {showFullscreen ? (
+          <Icons.Minimize size={14} />
+        ) : (
+          <Icons.Maximize size={14} />
+        )}
+      </button>
+    </div>
+  );
+
   const preview = (
     <LivePreviewWrapper showingCode={showingCode}>
       {showLivePreview && (
         <LivePreview sx={styles.preview} data-testid="live-preview" />
       )}
     </LivePreviewWrapper>
-  )
+  );
 
   const error = showLiveError && (
     <LiveError sx={styles.error} data-testid="live-error" />
-  )
+  );
 
   const editor = showingCode && (
     <div sx={styles.editor(theme)}>
       <LiveEditor data-testid="live-editor" />
     </div>
-  )
-  
+  );
+
   return (
     <Resizable {...resizableProps} data-testid="playground">
       <LiveProvider
@@ -138,20 +144,17 @@ export const Playground = ({
         </div>
         {error}
         {editor}
-        {showFullscreen &&
+        {showFullscreen && (
           <Dialog
             title="Live Preview"
             onClose={toggleFullscreen}
             data-testid="livepreview-fullscreen"
+            width={dialogWidth}
           >
-            <DialogActions onChangeSize={() =>{}} />
-            <div sx={styles.dialogPreviewWrapper(showingCode)}>
-              {preview}
-              {buttons}
-            </div>
-            {error}
-            {editor}
-          </Dialog>}
+            <DialogActions onChangeSize={onChangeSize} />
+            {preview}
+          </Dialog>
+        )}
       </LiveProvider>
     </Resizable>
   );

--- a/core/docz-components/src/components/Playground/styles.ts
+++ b/core/docz-components/src/components/Playground/styles.ts
@@ -33,6 +33,11 @@ export const previewWrapper = {
   position: 'relative',
 };
 
+export const dialogPreviewWrapper = (editorOpen: boolean) => ({
+  ...previewWrapper,
+  height: editorOpen ? '50%' : '98%'
+})
+
 export const preview = {
   m: 0,
   p: '20px',

--- a/core/docz-components/src/components/Portal/index.tsx
+++ b/core/docz-components/src/components/Portal/index.tsx
@@ -1,0 +1,22 @@
+/** @jsx jsx */
+import { createPortal } from "react-dom";
+
+interface PortalProps {
+  key?: string | undefined | null;
+  root?: string;
+}
+
+/**
+ * Helper component to mount the tooltip outside of the hovered element
+ * with the use of 'createPortal'. The tooltip will be rendered at the top node
+ * instead of inside the element with the tooltip
+ */
+export const Portal: React.FC<PortalProps> = ({
+  children,
+  key,
+  root = "___gatsby"
+}) => {
+  const rootElement = document.getElementById(root);
+  if (!rootElement) return null;
+  return createPortal(children, rootElement, key);
+};

--- a/core/docz-components/src/utils/hooks.tsx
+++ b/core/docz-components/src/utils/hooks.tsx
@@ -1,0 +1,33 @@
+import { useEffect } from 'react'
+
+export const useScrollLock = (): void => {
+  useEffect(() => {
+    if(document !== undefined){
+      document.body.style.overflow = 'hidden'
+    }
+    return () => {
+      if(document !== undefined) {
+        document.body.style.overflow = 'unset'
+      }
+    }
+  }, []);
+}
+
+export const useEscape = (callback: () => void): void => {
+  const keydownCallback = (event: any): void => {
+    if(event.keyCode === 27){
+      callback();
+    }
+    return
+  }
+  useEffect(() => {
+    if(document !== undefined){
+      document.addEventListener('keydown', keydownCallback, true)
+    }
+    return () => {
+      if(document !== undefined) {
+        document.removeEventListener('keydown', keydownCallback, true)
+      }
+    }
+  }, [])
+}


### PR DESCRIPTION
### Description

Add a fullscreen mode to `Playground`

### Features

- [X] Modal + button to open modal 
- [X] Close on escape
- [X] Close on click outside
- [X] Styling inside of modal (take up whole modal)
- [x] Use theme UI variables for styling (ability to mod the dialog from themeConfig)
- [x] Quick select viewport (mobile, tablet, desktop)

### Screenshots

![Kapture 2019-10-06 at 0 40 37](https://user-images.githubusercontent.com/21122051/66261695-87436480-e7d2-11e9-8adb-a77d2e381251.gif)
