### PR TITLE
fix(docz-rollup): handle defaultsExternal on windows

### DIFF
--- a/core/docz-rollup/src/index.js
+++ b/core/docz-rollup/src/index.js
@@ -27,7 +27,7 @@ const defaultExternal = id =>
   !id.startsWith('\0') &&
   !id.startsWith('~') &&
   !id.startsWith('.') &&
-  !id.startsWith('/')
+  !id.startsWith(process.platform === 'win32' ? process.cwd() : '/')
 
 const createOutput = (dir = 'dist', defaultOpts) => {
   const opts = omitOpts(defaultOpts)


### PR DESCRIPTION
### Description

Fixes building packages on windows: https://github.com/doczjs/docz/issues/783