### PR TITLE
fix(gatsby-theme-docz): able to set container width

### DIFF
--- a/core/gatsby-theme-docz/src/components/Layout/styles.js
+++ b/core/gatsby-theme-docz/src/components/Layout/styles.js
@@ -22,6 +22,7 @@ export const content = {
   maxWidth: 960,
   py: 5,
   px: 4,
+  variant: 'styles.Container',
   [media.tablet]: {
     py: 4,
     px: 4,


### PR DESCRIPTION
### Description

Fixes: #1098