### PR TITLE
fix(docz-core): index.tsx imports in index.mdx

### DIFF
--- a/core/docz-core/templates/gatsby-config.tpl.js
+++ b/core/docz-core/templates/gatsby-config.tpl.js
@@ -16,17 +16,18 @@ const config = {
     description: "<%- config.description %>"
   },
   plugins: [
-    {
-      resolve: 'gatsby-theme-docz',
-      options: <%- opts %>
-    },<% if (config.typescript) {%>
+    <% if (config.typescript) {%>
     {
       resolve: 'gatsby-plugin-typescript',
       options: {
         isTSX: true,
         allExtensions: true
       }
-    },<%}%><% if (isDoczRepo) {%>
+    },<%}%>
+    {
+      resolve: 'gatsby-theme-docz',
+      options: <%- opts %>
+    },<% if (isDoczRepo) {%>
     {
       resolve: 'gatsby-plugin-eslint',
       options: {


### PR DESCRIPTION
### Description

Attempt to fix https://github.com/doczjs/docz/issues/1164

It seems that if we put `gatsby-plugin-mdx` (set in `gatsby-theme-docz`) AFTER `gatsby-plugin-typescript`, it fixes the problem.

I've looked at another Gatsby starter with TypeScript and MDX and they [do the same](https://github.com/tylergreulich/gatsby-typescript-mdx-prismjs-starter/blob/64c6f8a3fc7896b8cdf5319ca9441c3c536354a4/gatsby-config.js#L11).

I don't know the side-effects but I've tested the typescript example and it works fine.