### PR TITLE
fix(docz-core): allow custom doczrc location with config cli flag

### DIFF
--- a/core/docz-core/src/bundler/machine/actions.ts
+++ b/core/docz-core/src/bundler/machine/actions.ts
@@ -18,7 +18,7 @@ const ensureFile = (filename: string, toDelete?: string) => {
 }
 
 export const ensureFiles = ({ args }: ServerMachineCtx) => {
-  const appPath = path.join(paths.docz, '..')
+  const appPath = paths.root
   const themeDirs = glob.sync(path.join(args.themesDir, '/gatsby-theme-**'), {
     cwd: appPath,
     onlyDirectories: true,
@@ -28,7 +28,17 @@ export const ensureFiles = ({ args }: ServerMachineCtx) => {
     const themeName = chunkedPath[chunkedPath.length - 1]
     fs.copySync(dir, path.join(paths.docz, args.themesDir, themeName))
   })
-  ensureFile('doczrc.js')
+  const sourceDoczRc = args.config
+    ? path.join(paths.root, args.config)
+    : path.join(paths.root, 'doczrc.js')
+  const destinationDoczRc = path.join(paths.docz, 'doczrc.js')
+  try {
+    fs.copySync(sourceDoczRc, destinationDoczRc)
+  } catch (err) {
+    console.error(
+      `Failed to copy doczrc.js from ${sourceDoczRc} to ${destinationDoczRc}`
+    )
+  }
   ensureFile('gatsby-browser.js')
   ensureFile('gatsby-ssr.js')
   ensureFile('gatsby-node.js')

--- a/core/docz-core/src/config/docz.ts
+++ b/core/docz-core/src/config/docz.ts
@@ -46,7 +46,7 @@ export const parseConfig = async (
   const defaultConfig = getBaseConfig(argv, { port, ...custom })
 
   const config = argv.config
-    ? loadFrom<Config>(path.resolve(argv.config), defaultConfig)
+    ? loadFrom<Config>(path.join(paths.docz, 'doczrc.js'), defaultConfig)
     : load<Config>('docz', defaultConfig)
 
   const reduceAsync = Plugin.reduceFromPluginsAsync<Config>(config.plugins)

--- a/core/docz-core/src/states/config.ts
+++ b/core/docz-core/src/states/config.ts
@@ -37,8 +37,9 @@ const getInitialConfig = (config: Config): Payload => {
 }
 
 const update = async (params: Params, initial: Payload, { config }: Config) => {
+  const pathToConfig = path.join(paths.docz, 'doczrc.js')
   const next = config
-    ? loadFrom(path.resolve(config), initial, true, true)
+    ? loadFrom(pathToConfig, initial, true, true)
     : load('docz', initial, true, true)
 
   params.setState('config', next)

--- a/examples/custom-config-location/.gitignore
+++ b/examples/custom-config-location/.gitignore
@@ -1,0 +1,2 @@
+.docz
+node_modules

--- a/examples/custom-config-location/README.md
+++ b/examples/custom-config-location/README.md
@@ -1,0 +1,41 @@
+# Docz with custom config location example
+
+## Using `create-docz-app`
+
+```sh
+npx create-docz-app docz-app --example custom-config-location
+# or
+yarn create docz-app docz-app --example custom-config-location
+```
+
+## Download manually
+
+```sh
+curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/custom-config-location
+mv custom-config-location docz-custom-config-location-example
+cd docz-custom-config-location-example
+```
+
+## Setup
+
+```sh
+yarn # npm i
+```
+
+## Run
+
+```sh
+yarn docz dev --config src/doczrc.js # or yarn dev
+```
+
+## Build
+
+```sh
+yarn docz build --config src/doczrc.js # or yarn build
+```
+
+## Serve built app
+
+```sh
+yarn serve # npm run serve
+```

--- a/examples/custom-config-location/package.json
+++ b/examples/custom-config-location/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "docz-example-custom-config-location",
+  "private": true,
+  "version": "2.0.0",
+  "license": "MIT",
+  "scripts": {
+    "dev": "docz dev --config src/doczrc.js",
+    "build": "docz build --config src/doczrc.js",
+    "serve": "docz serve"
+  },
+  "dependencies": {
+    "docz": "next",
+    "prop-types": "^15.7.2",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6",
+    "scheduler": "^0.15.0"
+  }
+}

--- a/examples/custom-config-location/src/components/Alert.jsx
+++ b/examples/custom-config-location/src/components/Alert.jsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import t from 'prop-types'
+
+const kinds = {
+  info: '#5352ED',
+  positive: '#2ED573',
+  negative: '#FF4757',
+  warning: '#FFA502',
+}
+
+const AlertStyled = ({ children, kind, ...rest }) => (
+  <div
+    style={{
+      padding: 20,
+      background: 'white',
+      borderRadius: 3,
+      color: 'white',
+      background: kinds[kind],
+    }}
+    {...rest}
+  >
+    {children}
+  </div>
+)
+
+export const Alert = props => <AlertStyled {...props} />
+
+Alert.propTypes = {
+  kind: t.oneOf(['info', 'positive', 'negative', 'warning']),
+}
+
+Alert.defaultProps = {
+  kind: 'info',
+}

--- a/examples/custom-config-location/src/components/Alert.mdx
+++ b/examples/custom-config-location/src/components/Alert.mdx
@@ -1,0 +1,28 @@
+---
+name: Alert
+menu: Components
+---
+
+import { Playground, Props } from 'docz'
+import { Alert } from './Alert'
+
+# Alert
+
+## Properties
+
+<Props of={Alert} />
+
+## Basic usage
+
+<Playground>
+  <Alert>Some message</Alert>
+</Playground>
+
+## Using different kinds
+
+<Playground>
+  <Alert kind="info">Some message</Alert>
+  <Alert kind="positive">Some message</Alert>
+  <Alert kind="negative">Some message</Alert>
+  <Alert kind="warning">Some message</Alert>
+</Playground>

--- a/examples/custom-config-location/src/doczrc.js
+++ b/examples/custom-config-location/src/doczrc.js
@@ -1,0 +1,4 @@
+export default {
+  menu: ['Getting Started', 'ComponentsA', 'ABD'],
+  title: 'My Documentation Title',
+}

--- a/examples/custom-config-location/src/index.mdx
+++ b/examples/custom-config-location/src/index.mdx
@@ -1,0 +1,20 @@
+---
+name: Getting Started
+route: /
+---
+
+# Getting Started
+
+Design systems enable teams to build better products faster by making design reusable—reusability makes scale possible. This is the heart and primary value of design systems. A design system is a collection of reusable components, guided by clear standards, that can be assembled together to build any number of applications.
+
+Regardless of the technologies and tools behind them, a successful design system follows these guiding principles:
+
+- **It’s consistent**. The way components are built and managed follows a predictable pattern.
+- **It’s self-contained**. Your design system is treated as a standalone dependency.
+- **It’s reusable**. You’ve built components so they can be reused in many contexts.
+- **It’s accessible**. Applications built with your design system are usable by as many people as possible, no matter how they access the web.
+- **It’s robust**. No matter the product or platform to which your design system is applied, it should perform with grace and minimal bugs.
+
+## Consistency
+
+Your first, most important task when starting out is to define the rules of your system, document them, and ensure that everyone follows them. When you have clearly documented code standards and best practices in place, designers and developers from across your organization can easily use and, more importantly, contribute to your design system.


### PR DESCRIPTION
Allow the user to set a custom doczrc location using the `config` cli flag

Example: 

```sh
yarn docz dev --config src/doczrc.js
```