### PR TITLE
fix(docz-core): copy user's doczrc.js to .docz/doczrc.js before running commands

### DIFF
--- a/core/docz-core/src/bundler/machine/actions.ts
+++ b/core/docz-core/src/bundler/machine/actions.ts
@@ -58,7 +58,7 @@ export const ensureFiles = ({ args }: ServerMachineCtx) => {
 }
 
 export const getIsFirstInstall = () => {
-  return !sh.test('-e', paths.docz)
+  return !sh.test('-e', path.join(paths.docz, 'package.json'))
 }
 export const getIsDoczRepo = () => {
   return sh.test('-e', path.join(paths.root, '../../core'))

--- a/core/docz-core/src/bundler/machine/services/create-resources.ts
+++ b/core/docz-core/src/bundler/machine/services/create-resources.ts
@@ -1,17 +1,23 @@
 import * as path from 'path'
 import * as fs from 'fs-extra'
-import { finds } from 'load-cfg'
 import { omit } from 'lodash/fp'
-import findUp from 'find-up'
-import sh from 'shelljs'
 
 import * as paths from '../../../config/paths'
 import { ServerMachineCtx } from '../context'
 import { outputFileFromTemplate } from '../../../utils/template'
 
-export const copyDoczRc = async () => {
-  const filepath = await findUp(finds('docz'))
-  filepath && sh.cp(filepath, paths.docz)
+export const copyDoczRc = (configPath?: string) => {
+  const sourceDoczRc = configPath
+    ? path.join(paths.root, configPath)
+    : path.join(paths.root, 'doczrc.js')
+  const destinationDoczRc = path.join(paths.docz, 'doczrc.js')
+  try {
+    fs.copySync(sourceDoczRc, destinationDoczRc)
+  } catch (err) {
+    console.error(
+      `Failed to copy doczrc.js from ${sourceDoczRc} to ${destinationDoczRc}`
+    )
+  }
 }
 
 const copyAndModifyPkgJson = async (ctx: ServerMachineCtx) => {
@@ -89,7 +95,7 @@ const writeGatsbyBrowser = async () =>
 
 export const createResources = async (ctx: ServerMachineCtx) => {
   try {
-    await copyDoczRc()
+    copyDoczRc(ctx.args.config)
     await copyAndModifyPkgJson(ctx)
     await writeEslintRc(ctx)
     await writeNotFound()

--- a/core/docz-core/src/bundler/machine/services/create-resources.ts
+++ b/core/docz-core/src/bundler/machine/services/create-resources.ts
@@ -14,9 +14,10 @@ export const copyDoczRc = (configPath?: string) => {
   try {
     fs.copySync(sourceDoczRc, destinationDoczRc)
   } catch (err) {
-    console.error(
-      `Failed to copy doczrc.js from ${sourceDoczRc} to ${destinationDoczRc}`
-    )
+    // console.error(
+    //   `Failed to copy doczrc.js from ${sourceDoczRc} to ${destinationDoczRc} : ${err.message}`,
+    //   err.stack
+    // )
   }
 }
 

--- a/core/docz-core/src/commands/build.ts
+++ b/core/docz-core/src/commands/build.ts
@@ -5,8 +5,10 @@ import { parseConfig } from '../config/docz'
 import { bundler as gatsby } from '../bundler'
 import { getIsFirstInstall } from '../bundler/machine/actions'
 import { init } from './init'
+import { copyDoczRc } from '../bundler/machine/services/create-resources'
 
 export const build = async (args: Arguments<any>) => {
+  copyDoczRc(args.config)
   const config = await parseConfig(args)
   const bundler = gatsby(config)
   const isFirstInstall = getIsFirstInstall()

--- a/core/docz-core/src/commands/dev.ts
+++ b/core/docz-core/src/commands/dev.ts
@@ -5,8 +5,10 @@ import logger from 'signale'
 
 import { parseConfig } from '../config/docz'
 import { bundler as gatsby } from '../bundler'
+import { copyDoczRc } from '../bundler/machine/services/create-resources'
 
 export const dev = async (args: Arguments<any>) => {
+  copyDoczRc(args.config)
   const config = await parseConfig(args)
   const bundler = gatsby(config)
   const app = await bundler.createApp()

--- a/core/docz-core/src/commands/init.ts
+++ b/core/docz-core/src/commands/init.ts
@@ -1,15 +1,17 @@
 process.setMaxListeners(Infinity)
 
 import { Arguments } from 'yargs'
-import { finds } from 'load-cfg'
-import findUp from 'find-up'
+import path from 'path'
 
 import { parseConfig } from '../config/docz'
 import { getIsFirstInstall, getIsDoczRepo } from '../bundler/machine/actions'
 import { ensureDirs, createResources } from '../bundler/machine/services'
+import { copyDoczRc } from '../bundler/machine/services/create-resources'
+import * as paths from '../config/paths'
 
 export const init = async (args: Arguments<any>) => {
-  const doczrcFilepath = await findUp(finds('docz'))
+  copyDoczRc(args.config)
+  const doczrcFilepath = path.join(paths.docz, 'doczrc.js')
   const config = await parseConfig(args)
   const isFirstInstall = getIsFirstInstall()
   const isDoczRepo = getIsDoczRepo()

--- a/other-packages/e2e-tests/index.js
+++ b/other-packages/e2e-tests/index.js
@@ -46,6 +46,10 @@ const examples = {
     path: path.join(rootPath, 'examples/typescript'),
     tmp: path.join(tmpPath, 'examples/typescript'),
   },
+  'custom-config-location': {
+    path: path.join(rootPath, 'examples/custom-config-location'),
+    tmp: path.join(tmpPath, 'examples/custom-config-location'),
+  },
 }
 
 const startLocalRegistry = async () => {
@@ -146,17 +150,13 @@ const setDoczVersionToCI = packageJson => {
 }
 
 const runTests = async () => {
-  // return
   console.log(`Preparing tmp examples dir.`)
   let PORT = 3000
   for (let exampleName in examples) {
     console.log(`🕕 Running ${exampleName} test`)
-    // await runCommand(`mkdir -p ${tmpPath}/examples/`)
     const example = examples[exampleName]
     await fs.ensureDir(`${tmpPath}/examples/${exampleName}`)
 
-    // copy example to a new temp directory
-    // await runCommand(`cp -r ${example.path} ${path.join(example.tmp, '..')}`)
     console.log()
     console.log(`Copying ${exampleName} example to a temporary directory.`)
     console.log(`Source : ${example.path}`)
@@ -164,8 +164,8 @@ const runTests = async () => {
     console.log()
 
     await fs.copy(example.path, example.tmp)
-    console.log(`Copied ${exampleName} example to a temporary directory.`)
 
+    console.log(`Copied ${exampleName} example to a temporary directory.`)
     console.log(`Modifying package.json in ${example.tmp}`)
 
     await updatePackageJson(example.tmp, pack => {
@@ -214,5 +214,3 @@ const cleanup = async () => {
   console.log('Exiting process')
   process.exit(0)
 })()
-
-// /var/folders/jn/3z685bls0mv64x4q1vjrzgy40000gn/T/tmp-546690gUnJPBhzg0U/examples/basic


### PR DESCRIPTION
Makes sure the `doczrc` file is in the expected location before the project config is parsed. 

Currently, when the `config` flag is passed to `docz`, `dev` and `build` commands work as expected but the first run logs an error in the console warning about a missing `doczrc.js` file.

This PR fixes this issue and adds an e2e test for using docz with a custom config location.