### PR TITLE
chore(docz-components): change item key and filename comparison

### DIFF
--- a/core/docz/src/components/Props.tsx
+++ b/core/docz/src/components/Props.tsx
@@ -117,7 +117,8 @@ export const Props: SFC<PropsProps> = ({
     stateProps &&
     stateProps.length > 0 &&
     stateProps.find(
-      item => item.key.includes(`/${componentName}.`) || item.key === filename
+      item =>
+        item.key.includes(`/${componentName}.`) || item.key.includes(filename)
     )
 
   const value = get('value', found) || []


### PR DESCRIPTION
### Description

When we try to write a Docz for a package located elsewhere (in a monorepo for example), we face the "`props`-problem".

In `doczrc.js`, if we set `docgenConfig.searchPath` to the relative root of our components, in the `stateProps` every item key is relative:

```js
{ key: '../../packages/components/src/Button/index.tsx', value: [] }
```

However, the `__filemeta.filename` will always be the `dist/index.js` file. To avoid that, I build my library with `babel-plugin-export-metadata` (cf https://github.com/doczjs/docz/pull/1173). The `__filemeta.filename` key is now resolved to:

```js
{ filename: 'src/Button/index.tsx' }
```

With the comparison `item.key === filename`, it still doesn't match. I changed it to `includes` because it's more permissive. Also, it's not a regression because if `item.key === filename` it will still match.