### PR TITLE
Pass the entry property down to the wrapper

### DIFF
--- a/core/gatsby-theme-docz/src/base/Layout.js
+++ b/core/gatsby-theme-docz/src/base/Layout.js
@@ -17,7 +17,7 @@ const Route = ({ children, entry, ...defaultProps }) => {
   if (!entry) return <NotFound />
   return (
     <MDXProvider components={components}>
-      <Wrapper>
+      <Wrapper doc={entry}>
         <Layout {...props}>{children}</Layout>
       </Wrapper>
     </MDXProvider>

--- a/core/gatsby-theme-docz/src/wrapper.js
+++ b/core/gatsby-theme-docz/src/wrapper.js
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-const Wrapper = ({ children, doc }) => (
+const Wrapper = ({ children }) => (
   <React.Fragment>{children}</React.Fragment>
 )
 export default Wrapper

--- a/core/gatsby-theme-docz/src/wrapper.js
+++ b/core/gatsby-theme-docz/src/wrapper.js
@@ -1,4 +1,6 @@
 import * as React from 'react'
 
-const Wrapper = ({ children }) => <React.Fragment>{children}</React.Fragment>
+const Wrapper = ({ children, doc }) => (
+  <React.Fragment>{children}</React.Fragment>
+)
 export default Wrapper


### PR DESCRIPTION
Resolves https://github.com/doczjs/docz/issues/1177

### Description

Passes the entry property down to the `Wrapper` component, which will allow developers to use it for things like setting meta headers in the header.