### PR TITLE
chore(docz-core): fix `resolveApp` when called from the docz project

### DIFF
--- a/core/docz-core/src/config/paths.ts
+++ b/core/docz-core/src/config/paths.ts
@@ -2,6 +2,8 @@ import * as fs from 'fs'
 import * as path from 'path'
 import * as resolve from 'resolve'
 
+import { Config } from './argv'
+
 export const ensureSlash = (filepath: any, needsSlash: boolean) => {
   const hasSlash = filepath.endsWith('/')
 
@@ -15,19 +17,21 @@ export const ensureSlash = (filepath: any, needsSlash: boolean) => {
 }
 
 export const root = fs.realpathSync(process.cwd())
-export const resolveApp = (to: string) => path.resolve(root, to)
-export const resolveOwn = (to: string) => path.resolve(__dirname, '../', to)
+const IS_DOCZ_PROJECT = path.parse(root).base === '.docz'
 
-export const checkIsDoczProject = (config: any) => {
+export const resolveApp = (to: string) =>
+  path.resolve(root, IS_DOCZ_PROJECT ? '../' : './', to)
+
+export const checkIsDoczProject = (config: Config) => {
   return path.parse(config.root || root).base === '.docz'
 }
 
-export const getRootDir = (config: any) => {
+export const getRootDir = (config: Config) => {
   const isDoczProject = checkIsDoczProject(config)
   return isDoczProject ? path.resolve(root, '../') : root
 }
 
-export const getThemesDir = (config: { themesDir: string }) => {
+export const getThemesDir = (config: Config) => {
   // resolve normalizes the new path and removes trailing slashes
   return path.resolve(path.join(getRootDir(config), config.themesDir))
 }
@@ -35,21 +39,16 @@ export const getThemesDir = (config: { themesDir: string }) => {
 export interface Paths {
   root: string
   templates: string
-  packageJson: string
   servedPath: (base: string) => string
 
   docz: string
   app: string
   cache: string
-  appPublic: string
-  appNodeModules: string
   appPackageJson: string
-  appYarnLock: string
   gatsbyConfig: string
   gatsbyBrowser: string
   gatsbyNode: string
   gatsbySSR: string
-  ownNodeModules: string
 
   checkIsDoczProject: (config: any) => boolean
   getRootDir: (config: any) => string
@@ -66,19 +65,12 @@ export interface Paths {
 
 export const templates = path.join(resolve.sync('docz-core'), '../templates')
 
-export const packageJson = resolveApp('package.json')
 export const servedPath = (base: string) => ensureSlash(base, true)
 
-const IS_DOCZ_PROJECT = path.parse(root).base === '.docz'
-
-export const docz = resolveApp(IS_DOCZ_PROJECT ? './' : '.docz')
+export const docz = resolveApp('.docz')
 export const cache = path.resolve(docz, '.cache/')
 export const app = path.resolve(docz, 'app/')
-export const appPublic = path.resolve(docz, 'public/')
-export const appNodeModules = resolveApp('node_modules')
 export const appPackageJson = resolveApp('package.json')
-export const appYarnLock = resolveOwn('yarn.lock')
-export const ownNodeModules = resolveOwn('node_modules')
 export const gatsbyConfig = resolveApp('gatsby-config.js')
 export const gatsbyBrowser = resolveApp('gatsby-browser.js')
 export const gatsbyNode = resolveApp('gatsby-node.js')


### PR DESCRIPTION
### Description

The `paths.ts` file was used at first from the base project hence the root was, let's say:
```
/Users/foo/bar/project
```
Then, this file is also used inside the Docz project, this time the root is:
```
/Users/foo/bar/project/.docz
```

However, `resolveApp` wants to always resolve the files in the base project.
I added a ternary to go up from one folder when we are in the Docz project.

This fixes [here](https://github.com/doczjs/docz/blob/cfe07b0c00fa5ff73bd194fbc48240a5315bc10e/core/docz-core/src/utils/repo-info.ts#L10-L17) where we want the project's package.json and not the docz' generated one.

I also cleaned some unused variables and added the `Config` type.

