### PR TITLE
style(docz-components): fix live preview background

### DIFF
--- a/core/docz-components/src/components/Playground/LivePreviewWrapper.tsx
+++ b/core/docz-components/src/components/Playground/LivePreviewWrapper.tsx
@@ -1,26 +1,29 @@
 /** @jsx jsx */
 import * as React from 'react';
-import { jsx, SxProps } from 'theme-ui';
+import { jsx, SxStyleProp } from 'theme-ui';
 import get from 'lodash/get';
+
 import { Theme } from '../../types';
 
 const styles = {
-  iframe: (showingCode: boolean, height = 'auto') =>
+  wrapper: (showingCode: boolean, height = 'auto') =>
     ({
       height,
       display: 'block',
       minHeight: '100%',
       width: 'calc(100% - 2px)',
+      bg: 'playground.bg',
       border: (t: Theme) =>
         `1px solid ${get(t, 'colors.playground.border', 'none')}`,
       borderRadius: showingCode ? '4px 4px 0 0' : '4px',
-    } as SxProps['sx']),
+    } as SxStyleProp),
 };
+
 type Props = { showingCode: boolean };
 
 export const LivePreviewWrapper: React.FC<Props> = ({
   children,
   showingCode,
 }) => {
-  return <div sx={styles.iframe(showingCode)}>{children}</div>;
+  return <div sx={styles.wrapper(showingCode)}>{children}</div>;
 };

--- a/core/docz-components/src/components/Playground/styles.ts
+++ b/core/docz-components/src/components/Playground/styles.ts
@@ -1,13 +1,14 @@
 import get from 'lodash/get';
 
 import * as mixins from '../../utils/mixins';
+import { Theme } from '../../types';
 import { PrismTheme } from 'prism-react-renderer';
+import { SxStyleProp } from 'theme-ui';
 
 export const editor = (theme: PrismTheme) =>
   ({
     p: 2,
-    border: (t: PrismTheme) =>
-      `1px solid ${get(t, 'colors.border', 'transparent')}`,
+    border: (t: Theme) => `1px solid ${get(t, 'colors.border', 'transparent')}`,
     borderRadius: '0 0 4px 4px',
     background: get(theme, 'plain.backgroundColor', 'none'),
     borderTop: 0,
@@ -18,7 +19,7 @@ export const editor = (theme: PrismTheme) =>
       lineHeight: '1.5em ',
       outline: 'none',
     },
-  } as any);
+  } as SxStyleProp);
 
 export const error = {
   m: 0,
@@ -36,7 +37,6 @@ export const previewWrapper = {
 export const preview = {
   m: 0,
   p: '20px',
-  bg: 'playground.bg',
 };
 
 export const buttons = {


### PR DESCRIPTION
### Description

I noticed a minor UI glitch with the live preview background and the radius. I moved the CSS property from the inner wrapper to the outer one.

### Screenshots

| Before | After |
| ------ | ----- |
| <img width="701" alt="Screenshot 2019-10-22 at 14 02 58" src="https://user-images.githubusercontent.com/5436545/67285753-708e5480-f4d8-11e9-82ea-306effa06fd1.png"> | <img width="718" alt="Screenshot 2019-10-22 at 14 28 02" src="https://user-images.githubusercontent.com/5436545/67285777-797f2600-f4d8-11e9-9853-33483195a7c3.png"> |