### PR TITLE
feat(docz): forward of prop to custom Props component

### DIFF
--- a/core/docz/src/components/Props.tsx
+++ b/core/docz/src/components/Props.tsx
@@ -97,6 +97,7 @@ export interface PropsComponentProps {
   isToggle?: boolean
   props: Record<string, Prop>
   getPropType(prop: Prop): string
+  of: ComponentWithDocGenInfo
 }
 
 export const Props: SFC<PropsProps> = ({
@@ -149,6 +150,7 @@ export const Props: SFC<PropsProps> = ({
       isToggle={isToggle}
       props={props}
       getPropType={getPropType}
+      of={component}
     />
   )
 }


### PR DESCRIPTION
### Description

This pull request forwards the `of` prop from the `<Props />` used in MDX to any custom `Props` component passed to the `componentsMap` component.

I want to be able to use the component name in my Prop component to add some more information, so therefore I need access to the passed component.
