### PR TITLE
fix(docz-core): always copy theme under src (#1105)

### DIFF
--- a/core/docz-core/src/bundler/machine/actions.ts
+++ b/core/docz-core/src/bundler/machine/actions.ts
@@ -27,7 +27,7 @@ export const ensureFiles = ({ args }: ServerMachineCtx) => {
   themeDirs.forEach(dir => {
     const chunkedPath = dir.split('/')
     const themeName = chunkedPath[chunkedPath.length - 1]
-    fs.copySync(dir, path.join(paths.docz, args.themesDir, themeName))
+    fs.copySync(dir, path.join(paths.docz, 'src', themeName))
   })
   copyDoczRc(args.config)
   ensureFile('gatsby-browser.js')


### PR DESCRIPTION
### Description

The theme directory should always be copied under _.docz/src/_ even when a custom path has been set using the `themesDir ` option.