### PR TITLE
style(gatsby-theme-docz): remove deprecation warning for grid

### DIFF
--- a/core/gatsby-theme-docz/src/components/Layout/styles.js
+++ b/core/gatsby-theme-docz/src/components/Layout/styles.js
@@ -3,13 +3,13 @@ import { media } from '~theme/breakpoints'
 export const main = {
   display: 'flex',
   flexDirection: 'column',
+  height: '100vh',
 }
 
 export const wrapper = {
   py: 0,
   flex: 1,
   display: 'grid',
-  gridTemplateRows: '100%',
   gridTemplateColumns: '250px 1fr',
   [media.tablet]: {
     display: 'block',


### PR DESCRIPTION
### Description

<img width="588" alt="Screenshot 2019-10-24 at 18 25 22" src="https://user-images.githubusercontent.com/5436545/67505576-d40cb380-f68b-11e9-90d2-478e45ad2653.png">

Due to the `grid-template-rows: 100%` declaration, we have a warning emited by Chrome in the console. I fixed it.