### PR TITLE
chore(docz-core): copy `.eslintignore` from project

### DIFF
--- a/core/docz-core/src/bundler/machine/services/create-resources.ts
+++ b/core/docz-core/src/bundler/machine/services/create-resources.ts
@@ -49,6 +49,16 @@ const writeEslintRc = async ({ isDoczRepo }: ServerMachineCtx) => {
   await fs.outputJSON(filepath, { extends: 'react-app' })
 }
 
+const copyEslintIgnore = async () => {
+  const filename = '.eslintignore'
+  const filepath = path.join(paths.root, filename)
+  const dest = path.join(paths.docz, filename)
+
+  if (fs.pathExistsSync(filepath)) {
+    await fs.copy(filepath, dest)
+  }
+}
+
 export const writeNotFound = async () => {
   const outputPath = path.join(paths.docz, 'src/pages/404.js')
   await outputFileFromTemplate('404.tpl.js', outputPath, {})
@@ -99,6 +109,7 @@ export const createResources = async (ctx: ServerMachineCtx) => {
     copyDoczRc(ctx.args.config)
     await copyAndModifyPkgJson(ctx)
     await writeEslintRc(ctx)
+    await copyEslintIgnore()
     await writeNotFound()
     await writeGatsbyConfig(ctx)
     await writeGatsbyConfigNode()


### PR DESCRIPTION
### Description

Gatsby has an Eslint plugin by default. It is run when we start the project. However, the cwd is at that time the `.docz` folder. Hence, if we add an `.eslintignore` in our project, it is not picked up. This add a build step to copy the file into the `.docz` folder if it exists.

Side note, I didn't understand what is the purpose of the function above, `writeEslintRc`, as it has an effect only in the Docz repository..