### PR TITLE
style(gatsby-theme-docz): collapse NavGroup by default

### DIFF
--- a/core/gatsby-theme-docz/src/components/NavGroup/index.js
+++ b/core/gatsby-theme-docz/src/components/NavGroup/index.js
@@ -8,7 +8,7 @@ import { ChevronDown } from '../Icons'
 
 export const NavGroup = ({ item }) => {
   const { menu } = item
-  const [subheadingsVisible, setShowsubheadings] = React.useState(true)
+  const [subheadingsVisible, setShowsubheadings] = React.useState(false)
   const toggleSubheadings = () => setShowsubheadings(!subheadingsVisible)
 
   return (


### PR DESCRIPTION
### Description

Pretty self-explanatory.. 😄 

<img width="314" alt="Screenshot 2019-10-25 at 12 33 19" src="https://user-images.githubusercontent.com/5436545/67564614-a5421c00-f723-11e9-9b32-2b4e23d1f88d.png">
