### PR TITLE
style(gatsby-theme-docz): remove word-wrap on Props component

### DIFF
--- a/core/gatsby-theme-docz/src/components/Props/styles.js
+++ b/core/gatsby-theme-docz/src/components/Props/styles.js
@@ -29,11 +29,10 @@ export const line = {
   },
 }
 
-export const column = {
+const column = {
   minWidth: 0,
   pb: 2,
   px: 3,
-  wordWrap: 'break-word',
   '& ~ &': {
     bg: 'red',
   },


### PR DESCRIPTION
### Description

I don't know why the `word-wrap` property was added but it makes the words not readable when the description is very long.

### Screenshots

| Before | After |
| ------ | ----- |
| <img width="752" alt="Screenshot 2019-10-28 at 11 35 55" src="https://user-images.githubusercontent.com/5436545/67672068-6b695380-f977-11e9-9ad7-5b1595e6b89a.png"> | <img width="762" alt="Screenshot 2019-10-28 at 11 36 01" src="https://user-images.githubusercontent.com/5436545/67672067-6b695380-f977-11e9-8415-3813dfafdd53.png"> |