### PR TITLE
Revert "feat(docz): expose <Code /> component"

### DIFF
--- a/core/docz/src/index.ts
+++ b/core/docz/src/index.ts
@@ -5,6 +5,3 @@ export { Props, PropsComponentProps } from './components/Props'
 export * from './hooks'
 export { theme } from './theme'
 export { doczState, Entry, MenuItem, ThemeConfig } from './state'
-
-const { Code } = require('gatsby-theme-docz/src/components/Code')
-export { Code }


### PR DESCRIPTION
Reverts doczjs/docz#1206

After further thought it would be much easier to import the `Code` component directly from `gatsby-theme-docz/src/components/Code`
 instead of exporting from docz


In your mdx : 

```mdx
import { Code } from 'gatsby-theme-docz/src/components/Code'

<Code className="ts">
	// ts code goes here
	let a:number
	a = 2
</Code>
```
