### PR TITLE
style(gatsby-theme-docz): keep NavGroup opened on item click

### DIFF
--- a/core/gatsby-theme-docz/src/components/NavGroup/index.js
+++ b/core/gatsby-theme-docz/src/components/NavGroup/index.js
@@ -1,14 +1,18 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
 import React from 'react'
+import { useCurrentDoc } from 'docz'
 
 import * as styles from './styles'
 import { NavLink } from '../NavLink'
 import { ChevronDown } from '../Icons'
 
 export const NavGroup = ({ item }) => {
-  const { menu } = item
-  const [subheadingsVisible, setShowsubheadings] = React.useState(false)
+  const current = useCurrentDoc()
+  const { name, menu } = item
+  const [subheadingsVisible, setShowsubheadings] = React.useState(
+    current.menu === name
+  )
   const toggleSubheadings = () => setShowsubheadings(!subheadingsVisible)
 
   return (


### PR DESCRIPTION
### Description

As all the menu items are now closed by default, if we open one and click on one item, it remount the component and closes it. This PR fixes that by keeping it opened.