### PR TITLE
fix(docz-core): add pathPrefix from config

### DIFF
--- a/core/docz-core/src/bundler/build.ts
+++ b/core/docz-core/src/bundler/build.ts
@@ -15,6 +15,7 @@ export const build: BuildFn = async (config, dist) => {
     // Append gatsby option `prefixPaths`to CLI args
     // https://www.gatsbyjs.org/docs/path-prefix/
     cliArgs.push('--prefixPaths')
+    cliArgs.push(config.base)
   }
   ensureFiles({ args: config })
   sh.cd(paths.docz)

--- a/core/docz-core/src/commands/serve.ts
+++ b/core/docz-core/src/commands/serve.ts
@@ -13,6 +13,7 @@ export const serve = async (args: Arguments<any>) => {
     // Append gatsby option `prefixPaths`to CLI args
     // https://www.gatsbyjs.org/docs/path-prefix/
     cliArgs.push('--prefixPaths')
+    cliArgs.push(config.base)
   }
 
   sh.cd(paths.docz)

--- a/examples/custom-base-path/.gitignore
+++ b/examples/custom-base-path/.gitignore
@@ -1,0 +1,2 @@
+.docz
+node_modules

--- a/examples/custom-base-path/README.md
+++ b/examples/custom-base-path/README.md
@@ -1,0 +1,41 @@
+# Basic Docz example
+
+## Using `create-docz-app`
+
+```sh
+npx create-docz-app docz-app-basic
+# or
+yarn create docz-app docz-app-basic
+```
+
+## Download manually
+
+```sh
+curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/basic
+mv basic docz-basic-example
+cd docz-basic-example
+```
+
+## Setup
+
+```sh
+yarn # npm i
+```
+
+## Run
+
+```sh
+yarn dev # npm run dev
+```
+
+## Build
+
+```sh
+yarn build # npm run build
+```
+
+## Serve built app
+
+```sh
+yarn serve # npm run serve
+```

--- a/examples/custom-base-path/doczrc.js
+++ b/examples/custom-base-path/doczrc.js
@@ -1,0 +1,3 @@
+export default {
+  base: '/base-path/',
+}

--- a/examples/custom-base-path/package.json
+++ b/examples/custom-base-path/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "docz-example-basic",
+  "private": true,
+  "version": "2.0.0-rc.41",
+  "license": "MIT",
+  "files": [
+    "src/",
+    "doczrc.js",
+    "package.json"
+  ],
+  "scripts": {
+    "dev": "docz dev",
+    "build": "docz build",
+    "serve": "docz serve"
+  },
+  "dependencies": {
+    "docz": "next",
+    "prop-types": "^15.7.2",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6",
+    "scheduler": "^0.15.0"
+  }
+}

--- a/examples/custom-base-path/src/components/Alert.jsx
+++ b/examples/custom-base-path/src/components/Alert.jsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import t from 'prop-types'
+
+const kinds = {
+  info: '#5352ED',
+  positive: '#2ED573',
+  negative: '#FF4757',
+  warning: '#FFA502',
+}
+
+const AlertStyled = ({ children, kind, ...rest }) => (
+  <div
+    style={{
+      padding: 20,
+      background: 'white',
+      borderRadius: 3,
+      color: 'white',
+      background: kinds[kind],
+    }}
+    {...rest}
+  >
+    {children}
+  </div>
+)
+
+export const Alert = props => <AlertStyled {...props} />
+
+Alert.propTypes = {
+  kind: t.oneOf(['info', 'positive', 'negative', 'warning']),
+}
+
+Alert.defaultProps = {
+  kind: 'info',
+}

--- a/examples/custom-base-path/src/components/Alert.mdx
+++ b/examples/custom-base-path/src/components/Alert.mdx
@@ -1,0 +1,28 @@
+---
+name: Alert
+menu: Components
+---
+
+import { Playground, Props } from 'docz'
+import { Alert } from './Alert'
+
+# Alert
+
+## Properties
+
+<Props of={Alert} />
+
+## Basic usage
+
+<Playground>
+  <Alert>Some message</Alert>
+</Playground>
+
+## Using different kinds
+
+<Playground>
+  <Alert kind="info">Some message</Alert>
+  <Alert kind="positive">Some message</Alert>
+  <Alert kind="negative">Some message</Alert>
+  <Alert kind="warning">Some message</Alert>
+</Playground>

--- a/examples/custom-base-path/src/index.mdx
+++ b/examples/custom-base-path/src/index.mdx
@@ -1,0 +1,20 @@
+---
+name: Getting Started
+route: /
+---
+
+# Getting Started
+
+Design systems enable teams to build better products faster by making design reusable—reusability makes scale possible. This is the heart and primary value of design systems. A design system is a collection of reusable components, guided by clear standards, that can be assembled together to build any number of applications.
+
+Regardless of the technologies and tools behind them, a successful design system follows these guiding principles:
+
+- **It’s consistent**. The way components are built and managed follows a predictable pattern.
+- **It’s self-contained**. Your design system is treated as a standalone dependency.
+- **It’s reusable**. You’ve built components so they can be reused in many contexts.
+- **It’s accessible**. Applications built with your design system are usable by as many people as possible, no matter how they access the web.
+- **It’s robust**. No matter the product or platform to which your design system is applied, it should perform with grace and minimal bugs.
+
+## Consistency
+
+Your first, most important task when starting out is to define the rules of your system, document them, and ensure that everyone follows them. When you have clearly documented code standards and best practices in place, designers and developers from across your organization can easily use and, more importantly, contribute to your design system.


### PR DESCRIPTION
### Description

Maps `base` in `doczrc.js` config to `gatsby`'s `prefixPaths` for `build` and `serve` script. 

#1042

