### PR TITLE
feat(docz-core): include components in index files

### DIFF
--- a/core/docz-core/src/config/docz.ts
+++ b/core/docz-core/src/config/docz.ts
@@ -26,7 +26,9 @@ export const doczRcBaseConfig = {
     /license.md/i,
   ],
   filterComponents: (files: string[]) =>
-    files.filter(filepath => /\/[A-Z]\w*\.(js|jsx|ts|tsx)$/.test(filepath)),
+    files.filter(filepath =>
+      /\/[A-Z]\w*(\/index)?\.(js|jsx|ts|tsx)$/.test(filepath)
+    ),
 }
 
 export const getBaseConfig = (


### PR DESCRIPTION
### Description

Changes the default `filterComponents` to include `index.{js,jsx,ts,tsx}` files as well (e.g. `components/Button/index.js`). This is a common way to gather assets related to a component together in one place. 

Fixes #1212.