### PR TITLE
docs: add example for the themesDir option (#1105)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Documenting code is one of the most important and time-heavy processes when you'
 - **[with typescript](https://github.com/pedronauck/docz/tree/master/examples/typescript)** - Using Docz with Typescript.
 - **[with flow](https://github.com/pedronauck/docz/tree/master/examples/flow)** - Using Docz with Flow.
 - **[with images](https://github.com/pedronauck/docz/tree/master/examples/images)** - Using Docz with images in mdx and jsx.
+- **[with custom themes](https://github.com/pedronauck/docz/tree/master/examples/with-themes-dir)** - Using Docz with a custom themes directory.
 
 - **[with sass](https://github.com/pedronauck/docz/tree/master/examples/sass)** - Using Docz parsing CSS with SASS.
 - **[with less](https://github.com/pedronauck/docz/tree/master/examples/less)** - Using Docz parsing CSS with LESS.

--- a/examples/with-themes-dir/.gitignore
+++ b/examples/with-themes-dir/.gitignore
@@ -1,0 +1,2 @@
+.docz
+node_modules

--- a/examples/with-themes-dir/README.md
+++ b/examples/with-themes-dir/README.md
@@ -1,0 +1,41 @@
+# With themesDir Docz example
+
+## Using `create-docz-app`
+
+```sh
+npx create-docz-app docz-app-with-themes-dir
+# or
+yarn create docz-app docz-app-with-themes-dir
+```
+
+## Download manually
+
+```sh
+curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/with-themes-dir
+mv with-themes-dir docz-with-themes-dir-example
+cd docz-with-themes-dir-example
+```
+
+## Setup
+
+```sh
+yarn # npm i
+```
+
+## Run
+
+```sh
+yarn dev # npm run dev
+```
+
+## Build
+
+```sh
+yarn build # npm run build
+```
+
+## Serve built app
+
+```sh
+yarn serve # npm run serve
+```

--- a/examples/with-themes-dir/doczrc.js
+++ b/examples/with-themes-dir/doczrc.js
@@ -1,0 +1,4 @@
+export default {
+  themesDir: 'theme',
+  menu: ['Getting Started', 'Components'],
+}

--- a/examples/with-themes-dir/package.json
+++ b/examples/with-themes-dir/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "docz-example-with-themes-dir",
+  "private": true,
+  "version": "2.0.0-rc.41",
+  "license": "MIT",
+  "files": [
+    "src/",
+    "theme/",
+    "doczrc.js",
+    "package.json"
+  ],
+  "scripts": {
+    "dev": "docz dev",
+    "build": "docz build",
+    "serve": "docz serve"
+  },
+  "dependencies": {
+    "docz": "next",
+    "prop-types": "^15.7.2",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6",
+    "scheduler": "^0.15.0"
+  }
+}

--- a/examples/with-themes-dir/src/components/Alert.jsx
+++ b/examples/with-themes-dir/src/components/Alert.jsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import t from 'prop-types'
+
+const kinds = {
+  info: '#5352ED',
+  positive: '#2ED573',
+  negative: '#FF4757',
+  warning: '#FFA502',
+}
+
+const AlertStyled = ({ children, kind, ...rest }) => (
+  <div
+    style={{
+      padding: 20,
+      background: 'white',
+      borderRadius: 3,
+      color: 'white',
+      background: kinds[kind],
+    }}
+    {...rest}
+  >
+    {children}
+  </div>
+)
+
+export const Alert = props => <AlertStyled {...props} />
+
+Alert.propTypes = {
+  kind: t.oneOf(['info', 'positive', 'negative', 'warning']),
+}
+
+Alert.defaultProps = {
+  kind: 'info',
+}

--- a/examples/with-themes-dir/src/components/Alert.mdx
+++ b/examples/with-themes-dir/src/components/Alert.mdx
@@ -1,0 +1,28 @@
+---
+name: Alert
+menu: Components
+---
+
+import { Playground, Props } from 'docz'
+import { Alert } from './Alert'
+
+# Alert
+
+## Properties
+
+<Props of={Alert} />
+
+## Basic usage
+
+<Playground>
+  <Alert>Some message</Alert>
+</Playground>
+
+## Using different kinds
+
+<Playground>
+  <Alert kind="info">Some message</Alert>
+  <Alert kind="positive">Some message</Alert>
+  <Alert kind="negative">Some message</Alert>
+  <Alert kind="warning">Some message</Alert>
+</Playground>

--- a/examples/with-themes-dir/src/index.mdx
+++ b/examples/with-themes-dir/src/index.mdx
@@ -1,0 +1,20 @@
+---
+name: Getting Started
+route: /
+---
+
+# Getting Started
+
+Design systems enable teams to build better products faster by making design reusable—reusability makes scale possible. This is the heart and primary value of design systems. A design system is a collection of reusable components, guided by clear standards, that can be assembled together to build any number of applications.
+
+Regardless of the technologies and tools behind them, a successful design system follows these guiding principles:
+
+- **It’s consistent**. The way components are built and managed follows a predictable pattern.
+- **It’s self-contained**. Your design system is treated as a standalone dependency.
+- **It’s reusable**. You’ve built components so they can be reused in many contexts.
+- **It’s accessible**. Applications built with your design system are usable by as many people as possible, no matter how they access the web.
+- **It’s robust**. No matter the product or platform to which your design system is applied, it should perform with grace and minimal bugs.
+
+## Consistency
+
+Your first, most important task when starting out is to define the rules of your system, document them, and ensure that everyone follows them. When you have clearly documented code standards and best practices in place, designers and developers from across your organization can easily use and, more importantly, contribute to your design system.

--- a/examples/with-themes-dir/theme/gatsby-theme-docz/components/Logo/index.js
+++ b/examples/with-themes-dir/theme/gatsby-theme-docz/components/Logo/index.js
@@ -1,0 +1,16 @@
+/** @jsx jsx */
+import { jsx, Flex } from 'theme-ui'
+import { Link, useConfig } from 'docz'
+
+import * as styles from './styles'
+
+export const Logo = () => {
+  const config = useConfig()
+  return (
+    <Flex aligmItems="center" sx={styles.logo} data-testid="logo">
+      <Link to="/" sx={styles.link}>
+        {config.title.toUpperCase()}
+      </Link>
+    </Flex>
+  )
+}

--- a/examples/with-themes-dir/theme/gatsby-theme-docz/components/Logo/styles.js
+++ b/examples/with-themes-dir/theme/gatsby-theme-docz/components/Logo/styles.js
@@ -1,0 +1,14 @@
+export const logo = {
+  letterSpacing: '-0.02em',
+  fontWeight: 600,
+  fontSize: 4,
+}
+
+export const link = {
+  fontWeight: 600,
+  color: 'header.text',
+  textDecoration: 'none',
+  ':hover': {
+    color: 'primary',
+  },
+}


### PR DESCRIPTION
### Description

_Follow up pull request of #1194._

Add an example folder called with-themes-dir with a custom `themesDir` option and a simple shadowing of the `Logo` component.

### Review

- [ ] Check the new example entry in the readme is correct.