### PR TITLE
Remove unused Fragment import

### DIFF
--- a/examples/styled-components/src/components/Alert.jsx
+++ b/examples/styled-components/src/components/Alert.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 import t from 'prop-types'
 


### PR DESCRIPTION
The dev server gives a warning about this after starting the styled-components example project for the first time:

```
warn ESLintError:
C:\Users\Chris\Desktop\docz-app-styled-docz\src\components\Alert.jsx
  1:17  warning  'Fragment' is defined but never used  no-unused-vars
```