### PR TITLE
fix: broken dark mode screen caused by main html tag's height

### DIFF
--- a/core/gatsby-theme-docz/src/components/Layout/styles.js
+++ b/core/gatsby-theme-docz/src/components/Layout/styles.js
@@ -3,7 +3,7 @@ import { media } from '~theme/breakpoints'
 export const main = {
   display: 'flex',
   flexDirection: 'column',
-  height: '100vh',
+  minHeight: '100vh',
 }
 
 export const wrapper = {


### PR DESCRIPTION
### Description

Dark mode's current behavior is broken. Whenever its children overflow its parent current height (which is of `100vh`), white margins shows up. Changing the `main` tag style from `height: 100vh` to `minHeight: 100vh` fixes this, as the `main` tag will then obey its children height.

### Screenshots

| Before | After |
| ------ | ----- |
|![Screenshot from 2019-11-06 13-55-56](https://user-images.githubusercontent.com/33183880/68319605-5b4f2380-009d-11ea-8732-fc47a29d4f34.png)|![Screenshot from 2019-11-06 13-58-28](https://user-images.githubusercontent.com/33183880/68319813-abc68100-009d-11ea-9400-4c36332077a0.png)|