### PR TITLE
fix(gatsby-theme-docz): non-latin anchor link

### DIFF
--- a/core/gatsby-theme-docz/src/components/NavLink/index.js
+++ b/core/gatsby-theme-docz/src/components/NavLink/index.js
@@ -17,7 +17,7 @@ const getCurrentHash = () => {
   if (typeof window === 'undefined') {
     return ''
   }
-  return window.location ? window.location.hash : ''
+  return window.location ? decodeURI(window.location.hash) : ''
 }
 
 export const NavLink = React.forwardRef(({ item, ...props }, ref) => {


### PR DESCRIPTION
### Description

Fix select sub headings in menu for non-latin characters.
Related with bug for navigate in main content (PR https://github.com/gatsbyjs/gatsby/pull/19376).