### PR TITLE
feat(docz): allow for custom properties in useMenus hook

### DIFF
--- a/core/docz/src/hooks/useMenus.ts
+++ b/core/docz/src/hooks/useMenus.ts
@@ -11,7 +11,7 @@ const noMenu = (entry: Entry) => !entry.menu
 const fromMenu = (menu: string) => (entry: Entry) => entry.menu === menu
 
 const entriesOfMenu = (menu: string, entries: Entry[]) =>
-  entries.filter(fromMenu(menu)).map(e => e as any) as MenuItem[]
+  entries.filter(fromMenu(menu))
 
 const parseMenu = (entries: Entry[]) => (name: string) => ({
   name,
@@ -21,9 +21,9 @@ const parseMenu = (entries: Entry[]) => (name: string) => ({
 type Menus = MenuItem[]
 
 const menusFromEntries = (entries: Entry[]) => {
-  const entriesWithoutMenu = entries.filter(noMenu).map(e => e) as any
+  const entriesWithoutMenu = entries.filter(noMenu)
   const menus = flatArrFromObject(entries, 'menu').map(parseMenu(entries))
-  return unionBy('name', menus, entriesWithoutMenu)
+  return unionBy('name', menus, entriesWithoutMenu as any)
 }
 
 const parseItemStr = (item: MenuItem | string) =>
@@ -130,11 +130,11 @@ export const useMenus = (opts?: UseMenusParams) => {
   const { entries, config } = useContext(doczState.context)
   if (!entries) return null
 
-  const arr = entries.map(({ value }) => value)
+  const arr = entries.map(({ value }) => value) as Entry[]
   const entriesMenu = menusFromEntries(arr)
   const sorted = useMemo(() => {
-    const merged = mergeMenus(entriesMenu as MenuItem[], config.menu)
-    const result = sortMenus(merged, config.menu)
+    const merged = mergeMenus(entriesMenu as any[], config.menu)
+    const result = sortMenus(merged, config.menu) as MenuItem[]
     return filterMenus(result, opts && opts.filter)
   }, [entries, config])
 

--- a/core/docz/src/hooks/useMenus.ts
+++ b/core/docz/src/hooks/useMenus.ts
@@ -9,14 +9,9 @@ import { Entry, MenuItem, doczState } from '../state'
 
 const noMenu = (entry: Entry) => !entry.menu
 const fromMenu = (menu: string) => (entry: Entry) => entry.menu === menu
-const entryAsMenu = (entry: Entry) => ({
-  name: entry.name,
-  route: entry.route,
-  parent: entry.parent,
-})
 
 const entriesOfMenu = (menu: string, entries: Entry[]) =>
-  entries.filter(fromMenu(menu)).map(entryAsMenu)
+  entries.filter(fromMenu(menu)).map(e => e as any) as MenuItem[]
 
 const parseMenu = (entries: Entry[]) => (name: string) => ({
   name,
@@ -26,7 +21,7 @@ const parseMenu = (entries: Entry[]) => (name: string) => ({
 type Menus = MenuItem[]
 
 const menusFromEntries = (entries: Entry[]) => {
-  const entriesWithoutMenu = entries.filter(noMenu).map(entryAsMenu) as any
+  const entriesWithoutMenu = entries.filter(noMenu).map(e => e) as any
   const menus = flatArrFromObject(entries, 'menu').map(parseMenu(entries))
   return unionBy('name', menus, entriesWithoutMenu)
 }

--- a/core/docz/src/state.tsx
+++ b/core/docz/src/state.tsx
@@ -26,6 +26,7 @@ export interface MenuItem {
   menu?: MenuItem[]
   order?: number
   parent?: string
+  [key: string]: any
 }
 
 export type ThemeConfig = Record<string, any>


### PR DESCRIPTION
### Description

Adding the feature of accessing custom properties from mdx-files in the useMenus hook.
As a side-effect of this, other preexisting fields such as slug and headings, are also included in the hook. This could potentially be improved by filtering these out, and only allowing for the original properties found in useMenus previously. 

### Pre-merge checklist

- [x] Check that all example projects are working.
