### PR TITLE
fix(docz-core): windows shadow copy gatsby-theme

### DIFF
--- a/core/docz-core/src/bundler/machine/actions.ts
+++ b/core/docz-core/src/bundler/machine/actions.ts
@@ -19,15 +19,16 @@ const ensureFile = (filename: string, toDelete?: string) => {
 }
 
 export const ensureFiles = ({ args }: ServerMachineCtx) => {
-  const appPath = paths.root
-  const themeDirs = glob.sync(path.join(args.themesDir, '/gatsby-theme-**'), {
+  const appPath = path.join(paths.root, args.themesDir)
+  const themeNames = glob.sync('gatsby-theme-**', {
     cwd: appPath,
     onlyDirectories: true,
   })
-  themeDirs.forEach(dir => {
-    const chunkedPath = dir.split('/')
-    const themeName = chunkedPath[chunkedPath.length - 1]
-    fs.copySync(dir, path.join(paths.docz, 'src', themeName))
+  themeNames.forEach(themeName => {
+    fs.copySync(
+      path.join(appPath, themeName),
+      path.join(paths.docz, 'src', themeName)
+    )
   })
   copyDoczRc(args.config)
   ensureFile('gatsby-browser.js')


### PR DESCRIPTION
### Description

Fix shadow copy gatsby-theme-docz for production build (`docz build`) on win32 platform,