### PR TITLE
fix(gatsby-theme-docz): ignore the .git folder

### DIFF
--- a/core/gatsby-theme-docz/gatsby-config.js
+++ b/core/gatsby-theme-docz/gatsby-config.js
@@ -45,6 +45,7 @@ module.exports = opts => {
         options: {
           ignore: [
             `${config.paths.docz}/**/*`,
+            `${config.paths.root}/.git/**/*`,
             // gatsby cache
             `${config.paths.root}/.cache/**/*`,
             // static assets with gatsby site setup


### PR DESCRIPTION
With this change, the git folder is ignored, improving the developer experience quite a bit :)
