### PR TITLE
style: update Playground margin

### DIFF
--- a/core/gatsby-theme-docz/src/components/Playground/index.js
+++ b/core/gatsby-theme-docz/src/components/Playground/index.js
@@ -36,7 +36,8 @@ export const Playground = ({ code, scope, language }) => {
       height: 'auto',
     },
     style: {
-      margin: '0 auto',
+      margin: 0,
+      marginRight: 'auto',
     },
     enable: {
       top: false,


### PR DESCRIPTION
### Description

I updated the margin so that when we resize the playground, it stays on the left instead of in the center. It makes it easier to follow and I think this is what expected from the user.

### Review

Not sure if there is anything to review

### Screenshots

| Before | After |
| ------ | ----- |
| ![Playground before](https://user-images.githubusercontent.com/14129033/68864518-97176800-06f1-11ea-8187-75afac6bc4fa.gif)  | ![Playground](https://user-images.githubusercontent.com/14129033/68864145-e7da9100-06f0-11ea-8da0-803f444c9809.gif)|




