### PR TITLE
fix(gatsby-theme-docz): sidebar mobile position

### DIFF
--- a/core/gatsby-theme-docz/src/components/Sidebar/styles.js
+++ b/core/gatsby-theme-docz/src/components/Sidebar/styles.js
@@ -6,10 +6,12 @@ export const global = {
   },
 }
 
+const HEADER_HEIGHT = 81
+
 export const overlay = ({ open }) => ({
   zIndex: 999,
   position: 'fixed',
-  top: 88,
+  top: HEADER_HEIGHT,
   right: 0,
   bottom: 0,
   left: 0,
@@ -37,7 +39,7 @@ export const wrapper = ({ open }) => ({
     zIndex: 9999,
     display: 'block',
     position: 'fixed',
-    top: 88,
+    top: HEADER_HEIGHT,
     left: 0,
     bottom: 0,
     width: 256,


### PR DESCRIPTION
### Description

The sidebar on mobile was a bit off by a few pixel

### Screenshots

| Before | After |
| ------ | ----- |
| ![Capture d’écran 2019-11-14 à 15 40 29](https://user-images.githubusercontent.com/14129033/68866974-7a7d2f00-06f5-11ea-97d2-74b1de0f4b3a.png)  | ![Capture d’écran 2019-11-14 à 15 43 05](https://user-images.githubusercontent.com/14129033/68867052-84069700-06f5-11ea-8213-d1d7b96a0c8f.png) |
