### PR TITLE
fix(docz-core): ignore test files

### DIFF
--- a/core/docz-core/src/config/docz.ts
+++ b/core/docz-core/src/config/docz.ts
@@ -27,6 +27,10 @@ export const doczRcBaseConfig = {
   ],
   filterComponents: (files: string[]) =>
     files.filter(filepath => {
+      const isTestFile = /\.(test|spec)\.(js|jsx|ts|tsx)$/.test(filepath);
+      if (isTestFile) {
+        return false;
+      }
       const startsWithCapitalLetter = /\/([A-Z]\w*)\.(js|jsx|ts|tsx)$/.test(
         filepath
       )


### PR DESCRIPTION
This change adds a regex that ignores test files by default.

I had this issue where props would some times not show up for certain components. Turns out, those components were typically the ones with tests.

When I looked in the docz state, I noticed that the test files were also included in the `props` array. This seemed a bit odd. After a bit of research, I understood that the docz `Props` component found the first entry, which often (but, for some reason, not always) was the test file. It was a hit, so the `Props` component was shown, but there was no props to show (since the test file didn't have any prop definitions).

This change filters out the test files by default, which should mitigate the problem, as well as speed up the process of parsing props for all users.

This has been a new problem, so it might have been a regression of sorts - not sure.