### PR TITLE
Add jsxFrag pragma

### DIFF
--- a/core/gatsby-theme-docz/src/components/Sidebar/index.js
+++ b/core/gatsby-theme-docz/src/components/Sidebar/index.js
@@ -1,4 +1,5 @@
 /** @jsx jsx */
+/** @jsxFrag React.Fragment */
 import React, { useState, useRef, useEffect } from 'react'
 import { Global } from '@emotion/core'
 import { jsx, Box } from 'theme-ui'


### PR DESCRIPTION


### Description

If a component is specifying a jsx pragma and is using `<></>` Fragment shorthand, they must also specify a fragment pragma.

https://babeljs.io/docs/en/next/babel-plugin-transform-react-jsx.html#fragments

Without this, i'm getting an error when using docz in conjunction with a plugin: 

`node_modules/gatsby-theme-docz/src/components/Sidebar/index.js: transform-react-jsx: pragma has been set but pragmafrag has not been set`

### Review

- [ ] Check the copy
- [ ] ...
- [ ] ...

### Pre-merge checklist

- [ ] ...
- [ ] ...

### Screenshots

| Before | After |
| ------ | ----- |
| Image  | Image |