### PR TITLE
fix(gatsby-theme-docz): remove webpack custom module resolution and circular dependency

### DIFF
--- a/core/gatsby-theme-docz/lib/onCreateWebpackConfig.js
+++ b/core/gatsby-theme-docz/lib/onCreateWebpackConfig.js
@@ -2,7 +2,7 @@ const fs = require('fs-extra')
 const path = require('path')
 const { Plugin, parseConfig } = require('docz-core')
 
-const nodeModules = path.resolve(__dirname, 'node_modules')
+// const nodeModules = path.resolve(__dirname, 'node_modules')
 const parentNodeModules = path.resolve(__dirname, '../../../node_modules')
 
 module.exports = async (params, opts) => {
@@ -21,11 +21,11 @@ module.exports = async (params, opts) => {
   }
 
   if (hasParentNodeModules) {
-    actions.setWebpackConfig({
-      resolve: {
-        modules: ['node_modules', nodeModules, parentNodeModules],
-      },
-    })
+    // actions.setWebpackConfig({
+    //   resolve: {
+    //     modules: ['node_modules', nodeModules, parentNodeModules],
+    //   },
+    // })
   }
 
   run('onCreateWebpackConfig', params, stage === 'develop', args, config)

--- a/core/gatsby-theme-docz/lib/onCreateWebpackConfig.js
+++ b/core/gatsby-theme-docz/lib/onCreateWebpackConfig.js
@@ -1,13 +1,7 @@
-const fs = require('fs-extra')
-const path = require('path')
 const { Plugin, parseConfig } = require('docz-core')
-
-// const nodeModules = path.resolve(__dirname, 'node_modules')
-const parentNodeModules = path.resolve(__dirname, '../../../node_modules')
 
 module.exports = async (params, opts) => {
   const { stage, actions, getConfig } = params
-  const hasParentNodeModules = fs.pathExistsSync(parentNodeModules)
   const args = await parseConfig(opts)
   const run = Plugin.runPluginsMethod(args.plugins)
   const config = getConfig()
@@ -18,14 +12,6 @@ module.exports = async (params, opts) => {
         extensions: config.resolve.extensions.concat(['.ts', '.tsx']),
       },
     })
-  }
-
-  if (hasParentNodeModules) {
-    // actions.setWebpackConfig({
-    //   resolve: {
-    //     modules: ['node_modules', nodeModules, parentNodeModules],
-    //   },
-    // })
   }
 
   run('onCreateWebpackConfig', params, stage === 'develop', args, config)

--- a/core/gatsby-theme-docz/lib/onCreateWebpackConfig.js
+++ b/core/gatsby-theme-docz/lib/onCreateWebpackConfig.js
@@ -23,11 +23,7 @@ module.exports = async (params, opts) => {
   if (hasParentNodeModules) {
     actions.setWebpackConfig({
       resolve: {
-        modules: [
-          // 'node_modules',
-          nodeModules,
-          parentNodeModules,
-        ],
+        modules: ['node_modules', nodeModules, parentNodeModules],
       },
     })
   }

--- a/core/gatsby-theme-docz/lib/onCreateWebpackConfig.js
+++ b/core/gatsby-theme-docz/lib/onCreateWebpackConfig.js
@@ -23,7 +23,7 @@ module.exports = async (params, opts) => {
   if (hasParentNodeModules) {
     actions.setWebpackConfig({
       resolve: {
-        modules: [nodeModules, parentNodeModules],
+        modules: ['node_modules', nodeModules, parentNodeModules],
       },
     })
   }

--- a/core/gatsby-theme-docz/lib/onCreateWebpackConfig.js
+++ b/core/gatsby-theme-docz/lib/onCreateWebpackConfig.js
@@ -23,7 +23,11 @@ module.exports = async (params, opts) => {
   if (hasParentNodeModules) {
     actions.setWebpackConfig({
       resolve: {
-        modules: ['node_modules', nodeModules, parentNodeModules],
+        modules: [
+          // 'node_modules',
+          nodeModules,
+          parentNodeModules,
+        ],
       },
     })
   }

--- a/core/gatsby-theme-docz/package.json
+++ b/core/gatsby-theme-docz/package.json
@@ -24,7 +24,6 @@
     "@theme-ui/typography": "^0.2.5",
     "babel-plugin-export-metadata": "2.0.0-rc.69",
     "copy-text-to-clipboard": "^2.1.0",
-    "docz": "2.0.0-rc.76",
     "docz-core": "2.0.0-rc.75",
     "emotion-theming": "^10.0.14",
     "fs-extra": "^8.1.0",

--- a/core/gatsby-theme-docz/package.json
+++ b/core/gatsby-theme-docz/package.json
@@ -24,7 +24,6 @@
     "@theme-ui/typography": "^0.2.5",
     "babel-plugin-export-metadata": "2.0.0-rc.69",
     "copy-text-to-clipboard": "^2.1.0",
-    "docz-core": "2.0.0-rc.75",
     "emotion-theming": "^10.0.14",
     "fs-extra": "^8.1.0",
     "gatsby": "^2.13.27",
@@ -59,7 +58,8 @@
   },
   "peerDependencies": {
     "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react-dom": "^16.8.0",
+    "docz": ">=2.0.0"
   },
   "gitHead": "74932cd67112bacd1e29780a202d466acdd79535"
 }

--- a/examples/gatsby/package.json
+++ b/examples/gatsby/package.json
@@ -21,6 +21,7 @@
     "serve": "gatsby serve"
   },
   "dependencies": {
+    "docz": "^2.0.0-rc.76",
     "gatsby": "^2.13.73",
     "gatsby-plugin-offline": "^2.2.7",
     "gatsby-plugin-sharp": "^2.2.18",

--- a/other-packages/e2e-tests/index.js
+++ b/other-packages/e2e-tests/index.js
@@ -105,7 +105,7 @@ const setupLocalRegistry = async () => {
   await startLocalRegistry()
   await updatePackageJson(paths.doczGatsbyTheme, packageJson => {
     set(packageJson, 'version', `0.0.${Date.now()}`)
-    return packageJson
+    return setDoczVersionToCI(packageJson)
   })
   await updatePackageJson(paths.docz, packageJson => {
     set(packageJson, 'version', `0.0.${Date.now()}`)

--- a/other-packages/e2e-tests/index.js
+++ b/other-packages/e2e-tests/index.js
@@ -105,7 +105,7 @@ const setupLocalRegistry = async () => {
   await startLocalRegistry()
   await updatePackageJson(paths.doczGatsbyTheme, packageJson => {
     set(packageJson, 'version', `0.0.${Date.now()}`)
-    return setDoczVersionToCI(packageJson)
+    return packageJson
   })
   await updatePackageJson(paths.docz, packageJson => {
     set(packageJson, 'version', `0.0.${Date.now()}`)


### PR DESCRIPTION
Addresses #1102

Breaking change IF docz is used in an existing Gatsby website you will need to add docz (in addition to gatsby-theme-docz) as a dependency.