### PR TITLE
fix(gatsby-theme-docz): remove typo from the theme styles

### DIFF
--- a/core/gatsby-theme-docz/src/theme/styles.js
+++ b/core/gatsby-theme-docz/src/theme/styles.js
@@ -43,7 +43,7 @@ const styles = {
     py: 3,
     px: 4,
     bg: 'blockquote.bg',
-    borderLeft: t => `5px solid ${t.colors.blockquote.boder}`,
+    borderLeft: t => `5px solid ${t.colors.blockquote.border}`,
     color: 'blockquote.color',
     fontStyle: 'italic',
     '> p': {

--- a/dev-env/basic/src/last-change-timestamp.js
+++ b/dev-env/basic/src/last-change-timestamp.js
@@ -1,5 +1,5 @@
 
 // Automatically generated do not edit
-const timestamp = 1574947203264
+const timestamp = 1568836075448
 export default timestamp
     

--- a/dev-env/basic/src/last-change-timestamp.js
+++ b/dev-env/basic/src/last-change-timestamp.js
@@ -1,5 +1,5 @@
 
 // Automatically generated do not edit
-const timestamp = 1568836075448
-export default timestamp    
+const timestamp = 1574947203264
+export default timestamp
     

--- a/dev-env/basic/src/last-change-timestamp.js
+++ b/dev-env/basic/src/last-change-timestamp.js
@@ -1,5 +1,4 @@
 
 // Automatically generated do not edit
 const timestamp = 1568836075448
-export default timestamp    
-    
+export default timestamp

--- a/dev-env/basic/src/last-change-timestamp.js
+++ b/dev-env/basic/src/last-change-timestamp.js
@@ -1,5 +1,5 @@
 
 // Automatically generated do not edit
 const timestamp = 1568836075448
-export default timestamp
+export default timestamp    
     


### PR DESCRIPTION
### Description
Hi docz team!
Just fixed the typo on the blockquote styles theme. It was causing problems when you extend the theme through shadowing. 
