### PR TITLE
Update example to use correct Regexp

### DIFF
--- a/examples/with-algolia-search/src/docs/general/usage-with-typescript.mdx
+++ b/examples/with-algolia-search/src/docs/general/usage-with-typescript.mdx
@@ -47,6 +47,6 @@ If you have particular needs or need to control exactly which files are being pi
 export default {
   filterComponents: files =>
     //This overrides the default filtering of components
-    files.filter(filepath => /[w-]*.(js|jsx|ts|tsx)$/.test(filepath)),
+    files.filter(filepath => /[\w-]+.(?:j|t)sx?$/.test(filepath)),
 }
 ```


### PR DESCRIPTION
### Description

`[w-]*` means to match `w` character literally or `-` character, zero or unlimited times.

So now this Regex is matchingeverything that endsWith `.ts` or `.tsx`, even a file with empty filename.
If this is intended, so the first parti of the regular expression is completely useless. Otherwise we could be more strict on this (since we are speaking of an example, of course)

Moreover the capturing group around `(js|jsx|ts|tsx)` is not needed since it's unused inside a `.test` method and it's heavier than `(?:j|t)sx?

This new regex does exactly 1/4 of the steps than before.
*Before*: 85 steps
![image](https://user-images.githubusercontent.com/1384475/70052205-17373c00-15d3-11ea-9533-087070fe16d1.png)

*After*: 21 steps
![image](https://user-images.githubusercontent.com/1384475/70052223-1ef6e080-15d3-11ea-9438-59299f788070.png)

### Review

- [ ] Check the copy
- [ ] ...
- [ ] ...

### Pre-merge checklist

- [ ] ...
- [ ] ...

### Screenshots

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/1384475/70052205-17373c00-15d3-11ea-9533-087070fe16d1.png)  | ![image](https://user-images.githubusercontent.com/1384475/70052223-1ef6e080-15d3-11ea-9438-59299f788070.png) |