### PR TITLE
Playground encapsulation / iframe around the playground

### DIFF
--- a/core/gatsby-theme-docz/package.json
+++ b/core/gatsby-theme-docz/package.json
@@ -41,6 +41,7 @@
     "prop-types": "^15.7.2",
     "re-resizable": "^6.1.0",
     "react-feather": "^2.0.3",
+    "react-frame-component": "^4.1.1",
     "react-helmet-async": "^1.0.4",
     "react-live": "^2.2.1",
     "rehype-docz": "^2.1.0",

--- a/core/gatsby-theme-docz/src/components/Playground/index.js
+++ b/core/gatsby-theme-docz/src/components/Playground/index.js
@@ -9,6 +9,7 @@ import copy from 'copy-text-to-clipboard'
 import { usePrismTheme } from '~utils/theme'
 import * as styles from './styles'
 import * as Icons from '../Icons'
+import { Preview } from '../Preview'
 
 const transformCode = code => {
   if (code.startsWith('()') || code.startsWith('class')) return code
@@ -67,7 +68,9 @@ export const Playground = ({ code, scope, language }) => {
         <div sx={styles.previewWrapper}>
           <div sx={styles.previewInner(showingCode)}>
             {showLivePreview && (
-              <LivePreview sx={styles.preview} data-testid="live-preview" />
+              <Preview>
+                <LivePreview sx={styles.preview} data-testid="live-preview" />
+              </Preview>
             )}
           </div>
           <div sx={styles.buttons}>

--- a/core/gatsby-theme-docz/src/components/Preview/index.js
+++ b/core/gatsby-theme-docz/src/components/Preview/index.js
@@ -1,0 +1,17 @@
+/** @jsx jsx */
+import { jsx } from 'theme-ui'
+import Frame from 'react-frame-component'
+
+export const Preview = ({ children }) => {
+  return (
+    <Frame
+      style={{
+        width: '100%',
+        height: '100%',
+        border: 'none',
+      }}
+    >
+      {children}
+    </Frame>
+  )
+}

--- a/examples/styled-components/package.json
+++ b/examples/styled-components/package.json
@@ -16,6 +16,7 @@
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
+    "react-frame-component": "^4.1.1",
     "styled-components": "^4.3.2"
   }
 }

--- a/examples/styled-components/src/gatsby-theme-docz/components/Preview/index.js
+++ b/examples/styled-components/src/gatsby-theme-docz/components/Preview/index.js
@@ -1,0 +1,25 @@
+/** @jsx jsx */
+import { jsx } from 'theme-ui'
+import * as React from 'react'
+import Frame, { FrameContextConsumer } from 'react-frame-component'
+import { StyleSheetManager } from 'styled-components'
+
+export const Preview = ({ children }) => {
+  return (
+    <Frame
+      style={{
+        width: '100%',
+        height: '100%',
+        border: 'none',
+      }}
+    >
+      <FrameContextConsumer>
+        {frameContext => (
+          <StyleSheetManager target={frameContext.document.head}>
+            <>{children}</>
+          </StyleSheetManager>
+        )}
+      </FrameContextConsumer>
+    </Frame>
+  )
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -15840,6 +15840,11 @@ react-feather@^2.0.3:
   dependencies:
     prop-types "^15.7.2"
 
+react-frame-component@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/react-frame-component/-/react-frame-component-4.1.1.tgz#ea8f7c518ef6b5ad72146dd1f648752369826894"
+  integrity sha512-NfJp90AvYA1R6+uSYafQ+n+UM2HjHqi4WGHeprVXa6quU9d8o6ZFRzQ36uemY82dlkZFzf2jigFx6E4UzNFajA==
+
 react-helmet-async@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/react-helmet-async/-/react-helmet-async-1.0.4.tgz#079ef10b7fefcaee6240fefd150711e62463cc97"


### PR DESCRIPTION
### Description

This PR adds a iFrame around every playground to solve problems like these: https://github.com/doczjs/docz/issues/1271 https://github.com/doczjs/docz/issues/1170

One example for the above mentioned issues is the component in dev-env/basic (https://github.com/doczjs/docz/tree/master/dev-env/basic) which currently inherits the font-family from the surrounding docz styles.

I still have open todos for this PR but already wanted to created it to make sure that I am on the correct way for solving these issues. :)

### Drawbacks and issues

- any css-in-js library would need changes to still be able to apply styles
- existing projects could already depend on the provided css from docz (font-family in basic example)

### Open topics

- [ ] implement examples for other css-in-js libraries
- [ ] automatic resizing of the iframe would be helpful