### PR TITLE
fix(docz-core): properly support node_modules for multiple file patterns

### DIFF
--- a/core/docz-core/src/lib/Entries.ts
+++ b/core/docz-core/src/lib/Entries.ts
@@ -47,14 +47,15 @@ export class Entries {
   }
 
   private async getMap(config: Config): Promise<EntryMap> {
-    const { paths, ignore, plugins, mdPlugins } = config
+    const { paths, ignore, plugins, mdPlugins, src } = config
     const fileMatchingPatterns = getFilesToMatch(config)
-
+    const srcHasNodeModules = src.indexOf('node_modules') !== -1
     // Hack around fast-glob not returning the whole set when many patterns are provided in the array
     let initialFiles: string[] = []
     for (let filePattern of fileMatchingPatterns) {
-      const globIgnore =
-        filePattern.indexOf('node_modules') === -1 ? ['**/node_modules/**'] : []
+      const filePatternHasNodeModules = filePattern.indexOf('node_modules') !== -1
+      const shouldIncludeNodeModules = srcHasNodeModules || filePatternHasNodeModules
+      const globIgnore = shouldIncludeNodeModules ? [] : ['**/node_modules/**']
 
       const filesFromPattern = await glob([filePattern], {
         cwd: paths.getRootDir(config),

--- a/core/docz-core/src/lib/Entries.ts
+++ b/core/docz-core/src/lib/Entries.ts
@@ -48,13 +48,14 @@ export class Entries {
 
   private async getMap(config: Config): Promise<EntryMap> {
     const { paths, ignore, plugins, mdPlugins } = config
-    const globIgnore =
-      config.src.indexOf('node_modules') === -1 ? ['**/node_modules/**'] : []
     const fileMatchingPatterns = getFilesToMatch(config)
 
     // Hack around fast-glob not returning the whole set when many patterns are provided in the array
     let initialFiles: string[] = []
     for (let filePattern of fileMatchingPatterns) {
+      const globIgnore =
+        filePattern.indexOf('node_modules') === -1 ? ['**/node_modules/**'] : []
+
       const filesFromPattern = await glob([filePattern], {
         cwd: paths.getRootDir(config),
         ignore: globIgnore,


### PR DESCRIPTION
### Description

Currently docs from node_modules are only supported when the src contains `node_modules`

This changes the code so that either src or any pattern can contain docs from `node_modules`

My config:
```js
{
  resolve: `gatsby-theme-docz`,
  options: {
    files: [
      `src/components/mdx/**/docs/*.{md,markdown,mdx}`,
      `node_modules/@gatsby-mdx-suite/*/docs/*.{md,markdown,mdx}`,
      `../../node_modules/@gatsby-mdx-suite/*/docs/*.{md,markdown,mdx}`,
    ]
  },
}
```