### PR TITLE
feat(docz-core): allow custom pattern for globbing components

### DIFF
--- a/core/docz-core/src/config/argv.ts
+++ b/core/docz-core/src/config/argv.ts
@@ -27,6 +27,7 @@ export interface DocgenConfig {
   resolver?: (ast: any, recast: any) => any
   propFilter?: (prop: any) => boolean
   searchPath: string
+  searchPatterns: string[]
 }
 
 export interface Menu {

--- a/core/docz-core/src/config/argv.ts
+++ b/core/docz-core/src/config/argv.ts
@@ -75,6 +75,7 @@ export interface Config extends Argv {
   themesDir: string
   mdxExtensions: string[]
   filterComponents: (files: string[]) => string[]
+  customPattern: string[]
 }
 
 export const setArgs = (yargs: Yargs) => {

--- a/core/docz-core/src/config/argv.ts
+++ b/core/docz-core/src/config/argv.ts
@@ -76,7 +76,6 @@ export interface Config extends Argv {
   themesDir: string
   mdxExtensions: string[]
   filterComponents: (files: string[]) => string[]
-  customPattern: string[]
 }
 
 export const setArgs = (yargs: Yargs) => {

--- a/core/docz-core/src/states/props.ts
+++ b/core/docz-core/src/states/props.ts
@@ -44,7 +44,11 @@ export const initial = (config: Config, pattern: string[]) => async (
 ) => {
   const { filterComponents } = config
   const cwd = paths.getRootDir(config)
-  const files = await fastglob(pattern, { cwd, caseSensitiveMatch: false })
+  const { customPattern } = config
+  const files = await fastglob(customPattern || pattern, {
+    cwd,
+    caseSensitiveMatch: false,
+  })
   const filtered = filterComponents ? filterComponents(files) : files
   const metadata = await docgen(filtered, config)
   p.setState('props', metadata)

--- a/core/docz-core/src/states/props.ts
+++ b/core/docz-core/src/states/props.ts
@@ -17,6 +17,10 @@ export const getPattern = (config: Config) => {
     docgenConfig: docgenConfig,
   } = config
 
+  if (docgenConfig.searchPatterns) {
+    return docgenConfig.searchPatterns
+  }
+
   const searchPath = docgenConfig.searchPath ? docgenConfig.searchPath : source
   const root = paths.getRootDir(config)
   const srcDir = path.resolve(root, searchPath)
@@ -44,11 +48,7 @@ export const initial = (config: Config, pattern: string[]) => async (
 ) => {
   const { filterComponents } = config
   const cwd = paths.getRootDir(config)
-  const { customPattern } = config
-  const files = await fastglob(customPattern || pattern, {
-    cwd,
-    caseSensitiveMatch: false,
-  })
+  const files = await fastglob(pattern, { cwd, caseSensitiveMatch: false })
   const filtered = filterComponents ? filterComponents(files) : files
   const metadata = await docgen(filtered, config)
   p.setState('props', metadata)


### PR DESCRIPTION
### Description

With #1315 I am able to include docs from within my dependencies and my source directory. This change adds support for globbing components from multiple directories.

My config:
```js
{
  resolve: `gatsby-theme-docz`,
  options: {
    files: [
      `src/components/mdx/**/docs/*.{md,markdown,mdx}`,
      `node_modules/@gatsby-mdx-suite/*/docs/*.{md,markdown,mdx}`,
      `../../node_modules/@gatsby-mdx-suite/*/docs/*.{md,markdown,mdx}`,
    ],
    customPattern: [
      `src/components/mdx/**/*.{js,jsx,mjs}`,
      `node_modules/@gatsby-mdx-suite/**/*.{js,jsx,mjs}`,
      `../../node_modules/@gatsby-mdx-suite/**/*.{js,jsx,mjs}`,
    ],
  },
}
```

### Review

- [x] is the naming correct?
- [x] should we merge the custom pattern with the default one?
