### PR TITLE
fix(docz-core): forward cli status code properly

### DIFF
--- a/core/docz-core/src/bundler/build.ts
+++ b/core/docz-core/src/bundler/build.ts
@@ -1,11 +1,11 @@
 import * as fs from 'fs-extra'
 import * as path from 'path'
-import spawn from 'cross-spawn'
 import sh from 'shelljs'
 
 import * as paths from '../config/paths'
 import { BuildFn } from '../lib/Bundler'
 import { ensureFiles } from './machine/actions'
+import { spawnSync } from '../utils/spawn'
 
 export const build: BuildFn = async (config, dist) => {
   const publicDir = path.join(paths.docz, 'public')
@@ -19,6 +19,6 @@ export const build: BuildFn = async (config, dist) => {
   }
   ensureFiles({ args: config })
   sh.cd(paths.docz)
-  spawn.sync('npm', cliArgs, { stdio: 'inherit' })
+  spawnSync('npm', cliArgs)
   await fs.copy(publicDir, dist)
 }

--- a/core/docz-core/src/commands/serve.ts
+++ b/core/docz-core/src/commands/serve.ts
@@ -1,10 +1,10 @@
-import spawn from 'cross-spawn'
 import sh from 'shelljs'
 
 import * as paths from '../config/paths'
+import { spawnSync } from '../utils/spawn'
 
 export const serve = async () => {
   const cliArgs = ['run', 'serve']
   sh.cd(paths.docz)
-  spawn.sync('npm', cliArgs, { stdio: 'inherit' })
+  spawnSync('npm', cliArgs)
 }

--- a/core/docz-core/src/utils/spawn.ts
+++ b/core/docz-core/src/utils/spawn.ts
@@ -1,0 +1,13 @@
+import crossSpawn from 'cross-spawn'
+
+export const spawnSync = (command: string, args?: readonly string[]) => {
+  const output = crossSpawn.sync(command, args, {
+    stdio: ['inherit', 'inherit', 'pipe'],
+  })
+
+  if (!output.stderr) {
+    return
+  }
+
+  process.exitCode = output.status || 1
+}


### PR DESCRIPTION
### Description

Currently, spawned processes (for example, `gatsby build`) run through CLI don't forward error code correctly to the parent process (`docz build`) producing success code (eg. `0`) even if some child processes failed. 
It can be problematic especially if we rely on it to do some CI/CD (like building a Docker image).
This PR solves the issue by forwarding properly child error code on `build` and `serve` commands.

### Screenshots

See `echo $?` output.

| Before | After |
| ------ | ----- |
| <img width="609" alt="Capture d’écran 2019-12-13 à 17 19 50" src="https://user-images.githubusercontent.com/10498826/70816453-d065f500-1dcf-11ea-9c37-81a607a3d4d4.png">  | <img width="611" alt="Capture d’écran 2019-12-13 à 17 15 50" src="https://user-images.githubusercontent.com/10498826/70816564-0d31ec00-1dd0-11ea-8a7d-dfbd9065b2cc.png"> |