### PR TITLE
fix(gatsby-theme-docz): make Props isToggle work again

### DIFF
--- a/core/gatsby-theme-docz/src/components/Props/index.js
+++ b/core/gatsby-theme-docz/src/components/Props/index.js
@@ -20,8 +20,8 @@ export const getDefaultValue = ({ defaultValue, type, flowType }) => {
   return defaultValue.value
 }
 
-export const Prop = ({ propName, prop, getPropType }) => {
-  const [showing, setShowing] = useState(false)
+export const Prop = ({ propName, prop, getPropType, isToggle }) => {
+  const [showing, setShowing] = useState(isToggle || false)
   if (!prop.type && !prop.flowType) return null
 
   const toggle = () => setShowing(s => !s)
@@ -65,13 +65,13 @@ export const Prop = ({ propName, prop, getPropType }) => {
   )
 }
 
-export const Props = ({ props, getPropType }) => {
+export const Props = ({ props, getPropType, isToggle }) => {
   const entries = Object.entries(props)
 
   return (
     <div sx={styles.container} data-testid="props">
       {entries.map(([key, prop]) => (
-        <Prop key={key} propName={key} prop={prop} getPropType={getPropType} />
+        <Prop key={key} propName={key} prop={prop} getPropType={getPropType} isToggle={isToggle} />
       ))}
     </div>
   )


### PR DESCRIPTION
### Description

fix https://github.com/doczjs/docz/issues/1323

### Screenshots

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/1776278/70892277-cb997f00-2023-11ea-811b-7b265710b931.png) | ![image](https://user-images.githubusercontent.com/1776278/70892237-bae90900-2023-11ea-8eac-eff149d61c2e.png)|