### PR TITLE
fix(gatsby-theme-docz): fix playground react-resize-detector usage

### DIFF
--- a/core/gatsby-theme-docz/src/components/Playground/index.js
+++ b/core/gatsby-theme-docz/src/components/Playground/index.js
@@ -90,7 +90,7 @@ export const Playground = ({ code, scope, language, useScoping = false }) => {
             )}
             <ReactResizeDetector
               handleHeight
-              onResize={(width, height) => {
+              onResize={({ height }) => {
                 setPreviewHeight(height)
               }}
             />
@@ -111,7 +111,7 @@ export const Playground = ({ code, scope, language, useScoping = false }) => {
             </div>
             <ReactResizeDetector
               handleHeight
-              onResize={(width, height) => {
+              onResize={({ height }) => {
                 setEditorHeight(height)
               }}
             />


### PR DESCRIPTION
Fixed usage of react-resize-detector onResize callback

### Description

Fixes: https://github.com/doczjs/docz/issues/1349

### Review

- [ ] Check the copy

### Pre-merge checklist

### Screenshots

No visual changes