### PR TITLE
fix: warning in Alert component

### DIFF
--- a/dev-env/basic/src/components/Alert.jsx
+++ b/dev-env/basic/src/components/Alert.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import t from 'prop-types'
 //@ts-ignore do not remove this to get live-reloading from changes made in packages
-import ChangesWhenAPackageSourceIsEdited from '../last-change-timestamp'
+import ChangesWhenAPackageSourceIsEdited from '../last-change-timestamp' // eslint-disable-line no-unused-vars
 
 const kinds = {
   info: '#5352ED',
@@ -14,7 +14,6 @@ const AlertStyled = ({ children, kind, ...rest }) => (
   <div
     style={{
       padding: 20,
-      background: 'white',
       borderRadius: 3,
       color: 'white',
       background: kinds[kind],


### PR DESCRIPTION
### Description

A few warning popped in dev mode.

<img width="692" alt="Capture d’écran 2020-01-10 à 16 40 44" src="https://user-images.githubusercontent.com/14129033/72165587-0cd54280-33c8-11ea-81b2-a26751d6d93d.png">
