### PR TITLE
fix(gatsby-theme-docz): removed unused gatsby-plugin-manifest

### DIFF
--- a/core/gatsby-theme-docz/package.json
+++ b/core/gatsby-theme-docz/package.json
@@ -30,7 +30,6 @@
     "gatsby-plugin-alias-imports": "^1.0.5",
     "gatsby-plugin-compile-es6-packages": "^2.0.0",
     "gatsby-plugin-emotion": "^4.1.2",
-    "gatsby-plugin-manifest": "^2.2.3",
     "gatsby-plugin-mdx": "^1.0.13",
     "gatsby-plugin-react-helmet-async": "^1.0.5",
     "gatsby-plugin-root-import": "^2.0.5",


### PR DESCRIPTION
### Description

`gatsby-theme-docz` has a dependency on `gatsby-plugin-manifest`, which in turn relies on a package called `sharp` that's causes install issues on Windows x64 machines. 

As `gatsby-plugin-manifest` serves a specific use case (see specs [here](https://www.gatsbyjs.org/packages/gatsby-plugin-manifest/)) and is actually never used in `gatsby-theme-docz`, it'd be a great help to remove it from the theme all together.
