### PR TITLE
[gatsby-theme-docz]: add aria-label attribute to theme button

### DIFF
--- a/core/gatsby-theme-docz/src/components/Header/index.js
+++ b/core/gatsby-theme-docz/src/components/Header/index.js
@@ -42,7 +42,11 @@ export const Header = props => {
             </Box>
           )}
           {showDarkModeSwitch && (
-            <button sx={styles.headerButton} onClick={toggleColorMode}>
+            <button
+              sx={styles.headerButton}
+              onClick={toggleColorMode}
+              aria-label={`Switch to ${colorMode} mode`}
+            >
               <Sun size={15} />
             </button>
           )}


### PR DESCRIPTION
issue: https://github.com/doczjs/docz/issues/1359

### Description

This PR adds an `aria-label` attribute on the Header's button responsible for switching between light and dark mode for screen readers.

### Review

- [ ] Check that there is an `aria-label="Switch to light|dark mode"` attribute on the theme button in the Header.
