### PR TITLE
fix(docz-core): pass down host when running serve

### DIFF
--- a/core/docz-core/src/commands/serve.ts
+++ b/core/docz-core/src/commands/serve.ts
@@ -11,10 +11,17 @@ export const serve = async (args: Arguments<any>) => {
 
   if (config.port) {
     cliArgs.push('--')
-    // Append gatsby option `port`to CLI args
+    // Append gatsby option `port` to CLI args
     // https://www.gatsbyjs.org/docs/cheat-sheet/#cheat_sheet-text
     cliArgs.push('--port')
     cliArgs.push(String(config.port))
+  }
+
+  if (config.host) {
+    // Append gatsby option `host` to CLI args
+    // https://www.gatsbyjs.org/docs/cheat-sheet/#cheat_sheet-text
+    cliArgs.push('--host')
+    cliArgs.push(String(config.host))
   }
 
   sh.cd(paths.docz)


### PR DESCRIPTION
### Description

When I start deploy docz project in my own server, i found that server publish ip address can not be access but localhost can, and after checkout [gatsby cli command](https://www.gatsbyjs.org/docs/gatsby-cli/#serve), i found the problem is host is always be `localhost` and can not be changed to others when use `docz serve`.