### PR TITLE
fix(gatsby-theme-docz): flex component aligmItems -> alignItems

### DIFF
--- a/core/gatsby-theme-docz/src/components/Logo/index.js
+++ b/core/gatsby-theme-docz/src/components/Logo/index.js
@@ -7,7 +7,7 @@ import * as styles from './styles'
 export const Logo = () => {
   const config = useConfig()
   return (
-    <Flex aligmItems="center" sx={styles.logo} data-testid="logo">
+    <Flex alignItems="center" sx={styles.logo} data-testid="logo">
       <Link to="/" sx={styles.link}>
         {config.title}
       </Link>


### PR DESCRIPTION
changed <Flex aligmItems="center"> to <Flex alignItems="center">

### Description

Fixed a typo in the Flex component embedded in the Logo component.

Changed `aligmItems='center'` to `alignItems="center"`