### PR TITLE
docs: add project in used-by section of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Start by building your site with `yarn docz build`, if you haven't provided a `d
 - **[FAB Specification](https://fab.dev/)** : 💎 FABs are a compile target for frontend applications.
 - **[@umijs/hooks](https://hooks.umijs.org/)**: React Hooks Library.
 - **[React Yandex Maps](https://react-yandex-maps.now.sh/)**: Yandex Maps API bindings for React.
+- **[Components-extra](https://components-extra.netlify.com)**: Customizable react component blocks built with material-ui and styled-components.
 - **[Add your site](https://github.com/doczjs/docz/edit/master/README.md)**
 
 ## Contributors


### PR DESCRIPTION
Hello,

### Description

This PR adds [components-extra](https://github.com/alexandre-lelain/components-extra) project to the `used-by` section of the README.

It is a library that aims to provide customizable molecule components to build the macro parts of a web page's UI (Navbar, Footer, CookiesBanner,...). It is built on top of material-ui & styled-components. Its documentation is built with **Docz** :)