### PR TITLE
fix(docz-core): always use custom prop filter if it's provided (#1403)

### DIFF
--- a/core/docz-core/src/utils/docgen/typescript.ts
+++ b/core/docz-core/src/utils/docgen/typescript.ts
@@ -165,13 +165,20 @@ function createServiceHost(
   }
 }
 
+const defaultPropFilter = (prop: any): boolean => {
+  return prop.parent == null || !prop.parent.fileName.includes('node_modules')
+}
+
 const parseFiles = (files: string[], config: Config, tsconfig: string) => {
   const opts = {
-    propFilter(prop: any): any {
-      if (prop.parent == null) return true
-      const propFilter = config.docgenConfig.propFilter
-      const val = propFilter && _.isFunction(propFilter) && propFilter(prop)
-      return !prop.parent.fileName.includes('node_modules') || Boolean(val)
+    propFilter(prop: any): boolean {
+      const customPropFilter = config.docgenConfig.propFilter
+      const propFilter =
+        customPropFilter && _.isFunction(customPropFilter)
+          ? customPropFilter
+          : defaultPropFilter
+
+      return Boolean(propFilter(prop))
     },
     componentNameResolver(exp: ts.Symbol, source: ts.SourceFile): any {
       const componentNameResolver = config.docgenConfig.resolver


### PR DESCRIPTION
### Description

Closes #1403 

I'm curious how y'all feel about considering this a "breaking change" vs just a "fix".

Technically the new behavior is different from the old behavior and folks who are using a custom propFilter might end up seeing more props after this is merged.

Here's a summary:

**Old behavior (without a custom prop filter):**
- any props that don't have a `parent` are included
- any props that have a non-node_module `parent` are included

**New behavior (without a custom prop filter):**
- same as old behavior

---

**Old behavior (with custom prop filter):**
- any props that don't have a `parent` are included
- any props that have a non-node_module `parent` are include
- any props that 1) have a `parent` and 2) `parent` is a node_module - will be run through the custom prop filter

This behavior seemed like a bug to me. The custom prop filter is almost always ignored and is only useful for white-listing some props that come from node_modules

**New behavior (with custom prop filter):**
- all props are run through the custom prop filter

So, if folks were actually relying on the old "buggy" behavior of propFilter just being a node_modules whitelist, they will need to add some logic to their propFilter in order to re-create the old behavior.

Overall I believe that this new API is the _right_ API, and it's just a matter of how to approach the change with the community, which I'll leave up to the maintainers