### PR TITLE
fix(babel-plugin-export-metadata): add case for export default memo()

### DIFF
--- a/other-packages/babel-plugin-export-metadata/tests/__snapshots__/index.test.js.snap
+++ b/other-packages/babel-plugin-export-metadata/tests/__snapshots__/index.test.js.snap
@@ -29,6 +29,25 @@ if (typeof foo5 !== 'undefined' && foo5 && foo5 === Object(foo5) && Object.isExt
 }"
 `;
 
+exports[`export-metadata export default works with Call expression 1`] = `
+"/* ExportDefaultDeclaration with Call expression */
+const foo = v => v;
+
+const __DOCZ_DUMMY_EXPORT_DEFAULT = foo(5);
+
+export default __DOCZ_DUMMY_EXPORT_DEFAULT;
+
+if (typeof __DOCZ_DUMMY_EXPORT_DEFAULT !== 'undefined' && __DOCZ_DUMMY_EXPORT_DEFAULT && __DOCZ_DUMMY_EXPORT_DEFAULT === Object(__DOCZ_DUMMY_EXPORT_DEFAULT) && Object.isExtensible(__DOCZ_DUMMY_EXPORT_DEFAULT) && !__DOCZ_DUMMY_EXPORT_DEFAULT.hasOwnProperty('__filemeta')) {
+  Object.defineProperty(__DOCZ_DUMMY_EXPORT_DEFAULT, '__filemeta', {
+    configurable: true,
+    value: {
+      name: \\"__DOCZ_DUMMY_EXPORT_DEFAULT\\",
+      filename: \\"tests/fixtures/export-default/with-identifier.js\\"
+    }
+  });
+}"
+`;
+
 exports[`export-metadata export default works with Class declaration 1`] = `
 "/* ExportDefaultDeclaration with Class declaration */
 export default class Bar6 {}

--- a/other-packages/babel-plugin-export-metadata/tests/fixtures/export-default/with-call-expression.js
+++ b/other-packages/babel-plugin-export-metadata/tests/fixtures/export-default/with-call-expression.js
@@ -1,0 +1,3 @@
+/* ExportDefaultDeclaration with Call expression */
+const foo = v => v
+export default foo(5)

--- a/other-packages/babel-plugin-export-metadata/tests/index.test.js
+++ b/other-packages/babel-plugin-export-metadata/tests/index.test.js
@@ -23,6 +23,9 @@ const exportDefaultFixtures = {
   withObjExpression: path.resolve(
     './tests/fixtures/export-default/with-obj-expression.js'
   ),
+  withCallExpression: path.resolve(
+    './tests/fixtures/export-default/with-call-expression.js'
+  ),
 }
 
 const reExportsFixtures = {
@@ -107,6 +110,15 @@ describe('export-metadata', () => {
 
     it('works with Identifier', () => {
       const result = transformSync(exportDefaultCode.withIdentifier, {
+        plugins: [plugin],
+        filename: exportDefaultFixtures.withIdentifier,
+      })
+
+      expect(result.code).toMatchSnapshot()
+    })
+
+    it('works with Call expression', () => {
+      const result = transformSync(exportDefaultCode.withCallExpression, {
         plugins: [plugin],
         filename: exportDefaultFixtures.withIdentifier,
       })


### PR DESCRIPTION
### Description

babel-plugin-export-metadata currently doesn't handle using call expression inside export default, such as:
```jsx
export default React.memo(Component)
```

This means it won't include `__filemeta` in the default export, so `<Props>` won't work correctly because it can't resolve the file path.

It resolves such case by separating expression and `export default`, to allow injecting `__filemeta` correctly.

```jsx
const __DOCZ_DUMMY_EXPORT_DEFAULT = React.memo(Component)
export default __DOCZ_DUMMY_EXPORT_DEFAULT
```
