### PR TITLE
fix(gatsby-theme-docz): content overflowing issue

### DIFF
--- a/core/gatsby-theme-docz/src/components/Layout/styles.js
+++ b/core/gatsby-theme-docz/src/components/Layout/styles.js
@@ -10,7 +10,7 @@ export const wrapper = {
   py: 0,
   flex: 1,
   display: 'grid',
-  gridTemplateColumns: '250px 1fr',
+  gridTemplateColumns: '250px minmax(0, 1fr)',
   minHeight: '100vh',
   [media.tablet]: {
     display: 'block',


### PR DESCRIPTION
### Description
In some cases the main container was overflowing, so a horizontal scroll bar was appearing which isn't what we expect. After digging a bit, this seems to solve the issue (related article: https://css-tricks.com/preventing-a-grid-blowout/)
