### PR TITLE
docs(migration_guide): fix URL for theme creation

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -82,7 +82,7 @@ import Theme from './my-custom-theme'
 export default (props) => <Theme {...props} />
 ```
 
-Check [here](https://www.docz.site/docs/creating-themes) for more information about how to create themes.
+Check [here](https://www.docz.site/docs/creating-your-themes) for more information about how to create themes.
 
 ## `wrapper` property removed
 The same thing happened here for the oldest `wrapper` property. Now you can wrap your entire application by just creating a file called `src/gatsby-theme-docz/wrapper.js`


### PR DESCRIPTION
### Description

URL for the theme creation in the `migration guide` is wrong, probably it is meant to be pointing to `/creating-your-themes`.

### Review

- [ ] Check the copy
- [ ] ...
- [ ] ...

### Pre-merge checklist

- [ ] ...
- [ ] ...

### Screenshots

| Before | After |
| ------ | ----- |
| Image  | Image |