### PR TITLE
feat(gatsby-theme-docz): configure SEO information from md/mdx files

### DIFF
--- a/core/gatsby-theme-docz/src/base/Layout.js
+++ b/core/gatsby-theme-docz/src/base/Layout.js
@@ -50,7 +50,7 @@ const Layout = ({ children, ...defaultProps }) => {
   const isTransclusion = includesTransclusion(db, defaultProps)
   return (
     <Fragment>
-      {entry && <SEO title={entry.value.name} />}
+      {entry && <SEO title={entry.value.name} {...entry.value} />}
       <Theme db={db} currentEntry={entry}>
         <Route {...defaultProps} entry={entry} isTransclusion={isTransclusion}>
           {children}


### PR DESCRIPTION
### Description

Change adds the possibility to set SEO meta information directly from *.md or *.mdx files without shadowing components.

For example:
```
---
title: Page1 Title
description: Description text
keywords: [keyword1, keyword1]
meta: []

name: Page1
route: /page1
---
```

Configuring SEO information is on a per-page basis. 

The page title can be customized and not depend on the page name. 

If this extra information is not provided in *.md or *.mdx file, the page name is used as a fallback. 

