### PR TITLE
docs(examples): use componentMap in customisation example

### DIFF
--- a/examples/with-algolia-search/src/docs/customizing/gatsby-theme.mdx
+++ b/examples/with-algolia-search/src/docs/customizing/gatsby-theme.mdx
@@ -137,7 +137,7 @@ const Theme = ({ children }) => {
   return (
     <ThemeProvider theme={config}>
       <Menu />
-      <ComponentsProvider components={baseComponents}>
+      <ComponentsProvider components={componentsMap}>
         {children}
       </ComponentsProvider>
     </ThemeProvider>


### PR DESCRIPTION
### Description

Updates the example docs to correctly use the custom `componentsMap`

### Screenshots

(Screenshots from the live website examples)

before: 

![image](https://user-images.githubusercontent.com/3030010/80672531-6e90f800-8af0-11ea-98a7-b10094e73dc4.png)

after:

![image](https://user-images.githubusercontent.com/3030010/80672572-86687c00-8af0-11ea-99aa-f3561b64be00.png)
