### PR TITLE
fix: add functions never to eslint rule

### DIFF
--- a/other-packages/eslint-config-docz-js/index.js
+++ b/other-packages/eslint-config-docz-js/index.js
@@ -14,7 +14,7 @@ module.exports = {
         argsIgnorePattern: '^_',
       },
     ],
-    'comma-dangle': ['error', 'always-multiline'],
+    'comma-dangle': ['error', 'always-multiline', { 'functions': 'never' }],
     'no-mixed-operators': 'error',
     'no-console': 'off',
     'react/prop-types': 'off',

--- a/other-packages/eslint-config-docz-js/package.json
+++ b/other-packages/eslint-config-docz-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-docz-js",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Eslint config of Docz for Javascript",
   "license": "MIT",
   "author": {

--- a/other-packages/eslint-config-docz-ts/index.js
+++ b/other-packages/eslint-config-docz-ts/index.js
@@ -7,7 +7,7 @@ module.exports = {
     'prettier/@typescript-eslint',
   ],
   rules: {
-    'comma-dangle': ['error', 'always-multiline'],
+    'comma-dangle': ['error', 'always-multiline', { 'functions': 'never' }],
     'no-mixed-operators': 'error',
     'no-console': 'off',
     'react/prop-types': 'off',

--- a/other-packages/eslint-config-docz-ts/package.json
+++ b/other-packages/eslint-config-docz-ts/package.json
@@ -24,22 +24,5 @@
     "eslint-plugin-mdx": "^1.6.1",
     "eslint-plugin-prettier": "^3.1.0",
     "eslint-plugin-react": "^7.13.0"
-  },
-  "devDependencies": {
-    "@babel/preset-typescript": "^7.3.3",
-    "@commitlint/cli": "^8.2.0",
-    "@commitlint/config-conventional": "^8.2.0",
-    "@commitlint/config-lerna-scopes": "^8.2.0",
-    "@types/fs-extra": "^8.0.0",
-    "@types/jest": "^24.0.15",
-    "@types/lodash": "^4.14.136",
-    "@types/node": "^12.6.8",
-    "@types/prettier": "^1.16.4",
-    "all-contributors-cli": "^6.8.0",
-    "babel-eslint": "^10.0.3",
-    "eslint-plugin-react": "^7.16.0",
-    "husky": "^3.0.0",
-    "lint-staged": "^9.2.0",
-    "ts-jest": "^24.0.2"
   }
 }

--- a/other-packages/eslint-config-docz-ts/package.json
+++ b/other-packages/eslint-config-docz-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-docz-ts",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Eslint config of Docz for Typescript",
   "license": "MIT",
   "author": {
@@ -24,5 +24,22 @@
     "eslint-plugin-mdx": "^1.6.1",
     "eslint-plugin-prettier": "^3.1.0",
     "eslint-plugin-react": "^7.13.0"
+  },
+  "devDependencies": {
+    "@babel/preset-typescript": "^7.3.3",
+    "@commitlint/cli": "^8.2.0",
+    "@commitlint/config-conventional": "^8.2.0",
+    "@commitlint/config-lerna-scopes": "^8.2.0",
+    "@types/fs-extra": "^8.0.0",
+    "@types/jest": "^24.0.15",
+    "@types/lodash": "^4.14.136",
+    "@types/node": "^12.6.8",
+    "@types/prettier": "^1.16.4",
+    "all-contributors-cli": "^6.8.0",
+    "babel-eslint": "^10.0.3",
+    "eslint-plugin-react": "^7.16.0",
+    "husky": "^3.0.0",
+    "lint-staged": "^9.2.0",
+    "ts-jest": "^24.0.2"
   }
 }


### PR DESCRIPTION
This would require a release bump of `eslint-config-docz-ts` to `2.1.1` on the NPM registry.
