### PR TITLE
fix(docz-core): normalize paths for file globbing

### DIFF
--- a/core/docz-core/__tests__/config.test.ts
+++ b/core/docz-core/__tests__/config.test.ts
@@ -1,40 +1,38 @@
 import * as path from 'path'
-import { setArgs } from '../src/config/argv'
+import { setArgs, Argv } from '../src/config/argv'
 import { getBaseConfig } from '../src/config/docz'
 import { getThemesDir } from '../src/config/paths'
-import yargs from 'yargs'
+import yargs, { Arguments } from 'yargs'
 
 describe('config.argv & config.docz', () => {
   test('works', () => {
     const { argv } = setArgs(yargs)
-    // expect(argv).toMatchInlineSnapshot(`undefined`)
-    //@ts-ignore
-    getBaseConfig(argv, {})
-    // expect(c)
+    getBaseConfig((argv as unknown) as Arguments<Argv>, {})
   })
 })
 
 describe('getThemeDir', () => {
   test('returns src/ for default config', () => {
     const { argv } = setArgs(yargs)
-    //@ts-ignore
-    const config = getBaseConfig(argv, {})
+    const config = getBaseConfig((argv as unknown) as Arguments<Argv>, {})
 
     expect(getThemesDir(config)).toBe(path.join(config.root, '/src'))
   })
 
-  test('returns correct path for custom themesDir entry', () => {
+  it('returns correct path for custom themesDir entry', () => {
     const { argv } = setArgs(yargs)
-    //@ts-ignore
-    const config = getBaseConfig(argv, { themesDir: 'theme' })
+    const config = getBaseConfig((argv as unknown) as Arguments<Argv>, {
+      themesDir: 'theme',
+    })
 
     expect(getThemesDir(config)).toBe(path.join(config.root, '/theme'))
   })
 
   test('custom themesDir entries with trailing slashes are handled correctly', () => {
     const { argv } = setArgs(yargs)
-    //@ts-ignore
-    const config = getBaseConfig(argv, { themesDir: 'theme/' })
+    const config = getBaseConfig((argv as unknown) as Arguments<Argv>, {
+      themesDir: 'theme/',
+    })
 
     expect(getThemesDir(config)).toBe(path.join(config.root, '/theme'))
   })

--- a/core/docz-core/__tests__/entries.test.ts
+++ b/core/docz-core/__tests__/entries.test.ts
@@ -1,4 +1,4 @@
-import { Entries } from '../src/lib/Entries'
+import { Entries, getFilesToMatch, matchFilesWithSrc } from '../src/lib/Entries'
 import { getTestConfig } from '../src/test-utils'
 
 describe('Entries', () => {
@@ -6,5 +6,36 @@ describe('Entries', () => {
     const config = getTestConfig()
     const entries = new Entries(config)
     expect(entries).toBeTruthy()
+  })
+
+  test('get map of entries', async () => {
+    const config = getTestConfig({
+      src: '__fixtures__',
+      files: '**/*.{mdx}',
+    })
+    const entries = new Entries(config)
+    const map = await entries.get()
+    expect(
+      Object.keys(map).includes('__fixtures__/Alert/Alert.mdx')
+    ).toBeTruthy()
+  })
+
+  test('with blank src and files', async () => {
+    const config = getTestConfig({
+      src: '',
+      files: 'docz/**/*.{mdx}',
+    })
+    const files = getFilesToMatch(config)
+    expect(matchFilesWithSrc(config)(files)[0]).toEqual('docz/**/*.{mdx}')
+  })
+  test('with src and files', async () => {
+    const config = getTestConfig({
+      src: '__fixtures__',
+      files: '**/*.{mdx}',
+    })
+    const files = getFilesToMatch(config)
+    expect(matchFilesWithSrc(config)(files)[0]).toEqual(
+      '__fixtures__/**/*.{mdx}'
+    )
   })
 })

--- a/core/docz-core/__tests__/states.test.ts
+++ b/core/docz-core/__tests__/states.test.ts
@@ -3,7 +3,8 @@ import { createConfigStateInput } from '../src/test-utils/data-bank'
 import { getBaseConfig } from '../src/config/docz'
 import * as paths from '../src/config/paths'
 import { Entries } from '../src/lib/Entries'
-import { setArgs } from '../src/config/argv'
+import { setArgs, Config, Argv } from '../src/config/argv'
+import { Arguments } from 'yargs'
 
 describe('states', () => {
   test('exports', () => {
@@ -16,7 +17,7 @@ describe('states', () => {
 
 describe('states.config', () => {
   test('config returns valid state', () => {
-    const state = states.config({})
+    const state = states.config({} as Config)
     expect(typeof state.close).toEqual('function')
     expect(typeof state.start).toEqual('function')
     expect(state.id).toEqual('config')
@@ -37,7 +38,7 @@ describe('states.config', () => {
 
 describe('states.entries', () => {
   test('entries returns start-able state', async () => {
-    const yargs = {
+    const yargs: any = {
       argv: {},
       option: jest.fn().mockImplementation((key, value) => {
         yargs.argv[value.alias ? value.alias : key] = value.default
@@ -45,15 +46,16 @@ describe('states.entries', () => {
       }),
     }
     const { argv } = setArgs(yargs)
-    //@ts-ignore
-    const config = { ...getBaseConfig(argv), paths }
+    const config = {
+      ...getBaseConfig((argv as unknown) as Arguments<Argv>),
+      paths,
+    }
     const entries = new Entries(config)
     const state = states.entries(entries, config)
     const setState = jest.fn()
     const getState = jest.fn()
     await state.start({ getState, setState })
     expect(getState).toBeCalledWith()
-    // expect(setState).toBeCalledWith('entries', [])
     state.close()
   })
 })

--- a/core/docz-core/src/lib/Entries.ts
+++ b/core/docz-core/src/lib/Entries.ts
@@ -9,6 +9,7 @@ import { Entry, EntryObj } from './Entry'
 import { Plugin } from './Plugin'
 import { Config } from '../config/argv'
 import { getRepoEditUrl } from '../utils/repo-info'
+import { unixPath } from '../utils/docgen'
 
 const mapToObj = (map: Map<any, any>) =>
   Array.from(map.entries()).reduce(
@@ -22,7 +23,7 @@ export const matchFilesWithSrc = (config: Config) => (files: string[]) => {
   const srcDir = path.resolve(rootDir, src)
   const prefix = path.relative(rootDir, srcDir)
   return files.map(file =>
-    file.startsWith(prefix) ? file : path.join(prefix, file)
+    unixPath(file.startsWith(prefix) ? file : path.join(prefix, file))
   )
 }
 

--- a/core/docz-core/src/lib/Entry.ts
+++ b/core/docz-core/src/lib/Entry.ts
@@ -13,6 +13,7 @@ import {
 
 import * as paths from '../config/paths'
 import { Config } from '../config/argv'
+import { unixPath } from '../utils/docgen'
 
 const createId = (file: string) =>
   crypto
@@ -73,14 +74,13 @@ export class Entry {
 
   private getFilepath(config: Config, file: string): string {
     const root = paths.getRootDir(config)
-    const fullpath = path.resolve(root, config.src, file)
+    const fullpath = path.resolve(
+      root,
+      file.startsWith(config.src) ? '' : config.src,
+      file
+    )
     const filepath = path.relative(root, fullpath)
-
-    if (process.platform === 'win32') {
-      return filepath.split('\\').join('/')
-    }
-
-    return filepath
+    return unixPath(filepath)
   }
 
   private getName(filepath: string, parsed: ParsedData): string {

--- a/core/docz-core/src/test-utils/index.ts
+++ b/core/docz-core/src/test-utils/index.ts
@@ -1,6 +1,6 @@
 import * as paths from '../config/paths'
-import yargs from 'yargs'
-import { setArgs, Config } from '../config/argv'
+import yargs, { Arguments } from 'yargs'
+import { setArgs, Config, Argv } from '../config/argv'
 import { Params } from '../lib/DataServer'
 import { getBaseConfig } from '../config/docz'
 
@@ -12,23 +12,21 @@ export const mockedParams = (): Params => {
   }
 }
 
-export const mockedArgv = () => {
+export const mockedArgv = (): Arguments<Argv> => {
   const yargsArgs: any = {
     argv: {},
-    //@ts-ignore
     option: jest.fn().mockImplementation((key, value) => {
       yargs.argv[value.alias ? value.alias : key] = value.default
       return yargs
     }),
   }
   const { argv } = setArgs(yargsArgs)
-  return argv
+  return (argv as unknown) as Arguments<Argv>
 }
 
 export const getTestConfig = (overrides?: Partial<Config>): Config => {
   const argv = mockedArgv()
   return {
-    //@ts-ignore
     ...getBaseConfig(argv),
     paths,
     typescript: true,

--- a/core/docz-core/tsconfig.json
+++ b/core/docz-core/tsconfig.json
@@ -5,7 +5,7 @@
     "outDir": "dist",
     "rootDir": "src",
     "declaration": true,
-    "types": ["node"],
+    "types": ["node", "jest"],
     "typeRoots": ["../../node_modules/@types", "node_modules/@types"]
   },
   "include": ["src/**/*", "src/types.d.ts"],


### PR DESCRIPTION
### Description

Adresses: #1461 

* Formats the paths when using `files` and `src` in the config
* Do not prefix path with `src` from config if already prefixed.