### PR TITLE
Includes alternative when running via npm

### DIFF
--- a/examples/with-algolia-search/src/docs/general/getting-started.mdx
+++ b/examples/with-algolia-search/src/docs/general/getting-started.mdx
@@ -64,7 +64,7 @@ yarn docz:dev # or yarn docz dev
 or
 
 ```bash
-npm run docz:dev
+npm run docz:dev # or npm run dev
 ```
 
 ## Develop


### PR DESCRIPTION
### Description

Hello, since the build of the standard project does not include the ```npm run docz:dev```, this PR includes the alternative for ```npm run dev```, which by default is configured in the project.

👍 