### PR TITLE
Include default value for "ignore" in "gatsby-config.js"

### DIFF
--- a/core/docz-core/src/config/argv.ts
+++ b/core/docz-core/src/config/argv.ts
@@ -107,7 +107,7 @@ export const setArgs = (yargs: Yargs) => {
     })
     .option('ignore', {
       type: 'array',
-      default: getEnv('docz.ignore', []),
+      default: getEnv('docz.ignore', doczRcBaseConfig.ignore),
     })
     .option('public', {
       type: 'string',


### PR DESCRIPTION
Fixes #1510 by using `doczRcBaseConfig.ignore` value