### PR TITLE
feat(gatsby-theme-docz): Add showEditor prop to Playground

### DIFF
--- a/core/docz/src/components/Playground.tsx
+++ b/core/docz/src/components/Playground.tsx
@@ -12,6 +12,7 @@ export interface PlaygroundProps {
   __code: string
   useScoping?: boolean
   language?: string
+  showEditor?: boolean
 }
 
 export const Playground: SFC<PlaygroundProps> = ({
@@ -24,6 +25,7 @@ export const Playground: SFC<PlaygroundProps> = ({
   __code,
   language,
   useScoping,
+  showEditor,
 }) => {
   const components = useComponents()
   const PlaygroundComponent = components.playground
@@ -41,6 +43,7 @@ export const Playground: SFC<PlaygroundProps> = ({
       code={__code}
       language={language}
       useScoping={useScoping}
+      showEditor={showEditor}
     />
   )
 }

--- a/core/docz/src/hooks/useComponents.tsx
+++ b/core/docz/src/hooks/useComponents.tsx
@@ -16,6 +16,7 @@ export interface PlaygroundProps {
   language?: string
   showLivePreview?: boolean
   useScoping?: boolean
+  showEditor?: boolean
 }
 
 export interface LayoutProps {

--- a/core/gatsby-theme-docz/src/components/Playground/index.js
+++ b/core/gatsby-theme-docz/src/components/Playground/index.js
@@ -42,7 +42,13 @@ const transformCode = code => {
   return `<React.Fragment>${code}</React.Fragment>`
 }
 
-export const Playground = ({ code, scope, language, useScoping = false }) => {
+export const Playground = ({
+  code,
+  scope,
+  language,
+  useScoping = false,
+  showEditor,
+}) => {
   const {
     themeConfig: { showPlaygroundEditor, showLiveError, showLivePreview },
   } = useConfig()
@@ -50,7 +56,9 @@ export const Playground = ({ code, scope, language, useScoping = false }) => {
   // Makes sure scope is only given on mount to avoid infinite re-render on hot reloads
   const [scopeOnMount] = React.useState(scope)
   const theme = usePrismTheme()
-  const [showingCode, setShowingCode] = React.useState(showPlaygroundEditor)
+  const [showingCode, setShowingCode] = React.useState(
+    showEditor !== undefined ? showEditor : showPlaygroundEditor
+  )
   const [width, setWidth] = React.useState('100%')
   const resizableProps = getResizableProps(width, setWidth)
 


### PR DESCRIPTION
If prop is present, use value of prop
Else use value from doczrc

### Description
Suggested here:
https://github.com/doczjs/docz/issues/1453#issuecomment-622483131


As far as I can tell there are no tests... Please do point me in the right direction if I'm mistaken!


--- 
Am also interested in the approach of using context to handle the components.
I found this PR https://github.com/doczjs/docz/pull/1197 but I'd like to understand why this is handled this way... 