### PR TITLE
feat(docz): support props proxy for HOC

### DIFF
--- a/core/docz/src/utils/humanize-prop.ts
+++ b/core/docz/src/utils/humanize-prop.ts
@@ -35,6 +35,9 @@ const getTypeStr = (type: PropType | FlowType): any => {
     case 'func':
       return 'Function'
     case 'shape':
+      if(type.computed === true){
+        return type.value;
+      }
       const shape = type.value
       const rst: any = {}
       Object.keys(shape).forEach(key => {


### PR DESCRIPTION
### Description

This pr is reinforces the <Props> component's ability of translation from propTypes to props tables via supporting the props proxy for HOCs. I have already proposed an issue [here](https://github.com/doczjs/docz/issues/1526) a couple of days ago.

### Screenshots

| Before | After |
| ------ | ----- |
| You can see the error in my issue  | ![image](https://user-images.githubusercontent.com/26187268/85239258-bd1f8c00-b3e7-11ea-99b2-fbf20bc79bea.png)
 |