### PR TITLE
feat: add gatsby https flag to use in dev mode

### DIFF
--- a/core/docz-core/src/bundler/machine/services/exec-dev-command.ts
+++ b/core/docz-core/src/bundler/machine/services/exec-dev-command.ts
@@ -36,8 +36,16 @@ export const execDevCommand = async ({ args }: ServerMachineCtx) => {
   const repoRootPath = get(args, 'repoRootPath', await findRootPath())
   const gatsbyPath = path.join(repoRootPath, 'node_modules/.bin/gatsby')
   // const cliArgs = process.argv.slice(3)
+
   // Has --https flag to enable https in dev mode
   const useHttps = args.https
+  const caFile = args.caFile
+  const keyFile = args.keyFile
+  const certFile = args.certFile
+  const caFileOption = caFile ? ['--ca-file', caFile] : []
+  const keyFileOption = keyFile ? ['--key-file', keyFile] : []
+  const certFileOption = certFile ? ['--cert-file', certFile] : []
+
   spawn(
     gatsbyPath,
     [
@@ -47,6 +55,9 @@ export const execDevCommand = async ({ args }: ServerMachineCtx) => {
       '--port',
       `${args.port}`,
       useHttps ? '--https' : '',
+      ...caFileOption,
+      ...keyFileOption,
+      ...certFileOption,
     ],
     {
       stdio: 'inherit',

--- a/core/docz-core/src/bundler/machine/services/exec-dev-command.ts
+++ b/core/docz-core/src/bundler/machine/services/exec-dev-command.ts
@@ -36,15 +36,25 @@ export const execDevCommand = async ({ args }: ServerMachineCtx) => {
   const repoRootPath = get(args, 'repoRootPath', await findRootPath())
   const gatsbyPath = path.join(repoRootPath, 'node_modules/.bin/gatsby')
   // const cliArgs = process.argv.slice(3)
+  // Has --https flag to enable https in dev mode
+  const useHttps = args.https
   spawn(
     gatsbyPath,
-    ['develop', '--host', `${args.host}`, '--port', `${args.port}`],
+    [
+      'develop',
+      '--host',
+      `${args.host}`,
+      '--port',
+      `${args.port}`,
+      useHttps ? '--https' : '',
+    ],
     {
       stdio: 'inherit',
       cwd: paths.docz,
     }
   )
-  const url = `http://${args.host}:${args.port}`
+  const protocol = useHttps ? 'https' : 'http'
+  const url = `${protocol}://${args.host}:${args.port}`
   console.log()
   console.log('Building app')
   await waitOn({

--- a/core/docz-core/src/config/argv.ts
+++ b/core/docz-core/src/config/argv.ts
@@ -66,6 +66,9 @@ export interface Argv {
   /** slugify separator */
   separator: string
   https: boolean
+  certFile: string
+  keyFile: string
+  caFile: string
 }
 
 export interface Config extends Argv {

--- a/core/docz-core/src/config/argv.ts
+++ b/core/docz-core/src/config/argv.ts
@@ -65,6 +65,7 @@ export interface Argv {
   description: string
   /** slugify separator */
   separator: string
+  https: boolean
 }
 
 export interface Config extends Argv {


### PR DESCRIPTION
### Description
In dev mode you might want to leverage https advantages. Gatsby comes built in with an ease to enabling https. This PR is to add in that option.

For example, if you want to test a post request to a https endpoint you'll need Docz to be running in https.