### PR TITLE
ignore .docz in Gatsby

### DIFF
--- a/examples/gatsby/.gitignore
+++ b/examples/gatsby/.gitignore
@@ -1,3 +1,5 @@
+.docz/
+
 # gatsby files
 .cache/
 public


### PR DESCRIPTION


### Description

All the other examples ignore .docz

I noticed that the .docz/app/db.json file is automatically generated and it seems unhelpful to treat it as source.  If this isn't right, then maybe we should ignore that one only.

