### PR TITLE
fix(babel-plugin-export-metadata): fix `hasOwnProperty` method call

### DIFF
--- a/other-packages/babel-plugin-export-metadata/src/index.js
+++ b/other-packages/babel-plugin-export-metadata/src/index.js
@@ -3,7 +3,13 @@ const { default: template } = require('@babel/template')
 const { get } = require('lodash')
 
 const buildFileMeta = template(`
-  if (typeof ID !== 'undefined' && ID && ID === Object(ID) && Object.isExtensible(ID) && !ID.hasOwnProperty('__filemeta')) {
+  if (
+    typeof ID !== 'undefined' &&
+    ID &&
+    ID === Object(ID) &&
+    Object.isExtensible(ID) &&
+    !Object.prototype.hasOwnProperty.call(ID, '__filemeta')
+  ) {
     Object.defineProperty(ID, '__filemeta', {
       configurable: true,
       value: {

--- a/other-packages/babel-plugin-export-metadata/tests/__snapshots__/index.test.js.snap
+++ b/other-packages/babel-plugin-export-metadata/tests/__snapshots__/index.test.js.snap
@@ -8,7 +8,7 @@ let bar5 = () => {};
 
 export default [foo5, bar5];
 
-if (typeof bar5 !== 'undefined' && bar5 && bar5 === Object(bar5) && Object.isExtensible(bar5) && !bar5.hasOwnProperty('__filemeta')) {
+if (typeof bar5 !== 'undefined' && bar5 && bar5 === Object(bar5) && Object.isExtensible(bar5) && !Object.prototype.hasOwnProperty.call(bar5, '__filemeta')) {
   Object.defineProperty(bar5, '__filemeta', {
     configurable: true,
     value: {
@@ -18,7 +18,7 @@ if (typeof bar5 !== 'undefined' && bar5 && bar5 === Object(bar5) && Object.isExt
   });
 }
 
-if (typeof foo5 !== 'undefined' && foo5 && foo5 === Object(foo5) && Object.isExtensible(foo5) && !foo5.hasOwnProperty('__filemeta')) {
+if (typeof foo5 !== 'undefined' && foo5 && foo5 === Object(foo5) && Object.isExtensible(foo5) && !Object.prototype.hasOwnProperty.call(foo5, '__filemeta')) {
   Object.defineProperty(foo5, '__filemeta', {
     configurable: true,
     value: {
@@ -37,7 +37,7 @@ const __DOCZ_DUMMY_EXPORT_DEFAULT = foo(5);
 
 export default __DOCZ_DUMMY_EXPORT_DEFAULT;
 
-if (typeof __DOCZ_DUMMY_EXPORT_DEFAULT !== 'undefined' && __DOCZ_DUMMY_EXPORT_DEFAULT && __DOCZ_DUMMY_EXPORT_DEFAULT === Object(__DOCZ_DUMMY_EXPORT_DEFAULT) && Object.isExtensible(__DOCZ_DUMMY_EXPORT_DEFAULT) && !__DOCZ_DUMMY_EXPORT_DEFAULT.hasOwnProperty('__filemeta')) {
+if (typeof __DOCZ_DUMMY_EXPORT_DEFAULT !== 'undefined' && __DOCZ_DUMMY_EXPORT_DEFAULT && __DOCZ_DUMMY_EXPORT_DEFAULT === Object(__DOCZ_DUMMY_EXPORT_DEFAULT) && Object.isExtensible(__DOCZ_DUMMY_EXPORT_DEFAULT) && !Object.prototype.hasOwnProperty.call(__DOCZ_DUMMY_EXPORT_DEFAULT, '__filemeta')) {
   Object.defineProperty(__DOCZ_DUMMY_EXPORT_DEFAULT, '__filemeta', {
     configurable: true,
     value: {
@@ -52,7 +52,7 @@ exports[`export-metadata export default works with Class declaration 1`] = `
 "/* ExportDefaultDeclaration with Class declaration */
 export default class Bar6 {}
 
-if (typeof Bar6 !== 'undefined' && Bar6 && Bar6 === Object(Bar6) && Object.isExtensible(Bar6) && !Bar6.hasOwnProperty('__filemeta')) {
+if (typeof Bar6 !== 'undefined' && Bar6 && Bar6 === Object(Bar6) && Object.isExtensible(Bar6) && !Object.prototype.hasOwnProperty.call(Bar6, '__filemeta')) {
   Object.defineProperty(Bar6, '__filemeta', {
     configurable: true,
     value: {
@@ -67,7 +67,7 @@ exports[`export-metadata export default works with Function declaration 1`] = `
 "/* ExportDefaultDeclaration with Function declaration */
 export default function foo6() {}
 
-if (typeof foo6 !== 'undefined' && foo6 && foo6 === Object(foo6) && Object.isExtensible(foo6) && !foo6.hasOwnProperty('__filemeta')) {
+if (typeof foo6 !== 'undefined' && foo6 && foo6 === Object(foo6) && Object.isExtensible(foo6) && !Object.prototype.hasOwnProperty.call(foo6, '__filemeta')) {
   Object.defineProperty(foo6, '__filemeta', {
     configurable: true,
     value: {
@@ -83,7 +83,7 @@ exports[`export-metadata export default works with Identifier 1`] = `
 let foo3 = 5;
 export default foo3;
 
-if (typeof foo3 !== 'undefined' && foo3 && foo3 === Object(foo3) && Object.isExtensible(foo3) && !foo3.hasOwnProperty('__filemeta')) {
+if (typeof foo3 !== 'undefined' && foo3 && foo3 === Object(foo3) && Object.isExtensible(foo3) && !Object.prototype.hasOwnProperty.call(foo3, '__filemeta')) {
   Object.defineProperty(foo3, '__filemeta', {
     configurable: true,
     value: {
@@ -101,7 +101,7 @@ export default {
   bar4: () => {}
 };
 
-if (typeof bar4 !== 'undefined' && bar4 && bar4 === Object(bar4) && Object.isExtensible(bar4) && !bar4.hasOwnProperty('__filemeta')) {
+if (typeof bar4 !== 'undefined' && bar4 && bar4 === Object(bar4) && Object.isExtensible(bar4) && !Object.prototype.hasOwnProperty.call(bar4, '__filemeta')) {
   Object.defineProperty(bar4, '__filemeta', {
     configurable: true,
     value: {
@@ -111,7 +111,7 @@ if (typeof bar4 !== 'undefined' && bar4 && bar4 === Object(bar4) && Object.isExt
   });
 }
 
-if (typeof foo4 !== 'undefined' && foo4 && foo4 === Object(foo4) && Object.isExtensible(foo4) && !foo4.hasOwnProperty('__filemeta')) {
+if (typeof foo4 !== 'undefined' && foo4 && foo4 === Object(foo4) && Object.isExtensible(foo4) && !Object.prototype.hasOwnProperty.call(foo4, '__filemeta')) {
   Object.defineProperty(foo4, '__filemeta', {
     configurable: true,
     value: {
@@ -132,7 +132,7 @@ let baz = 'baz';
 export { foo as default, bar as foobar, baz };
 /* ExportNamedDeclaration with Variable declarations */
 
-if (typeof baz !== 'undefined' && baz && baz === Object(baz) && Object.isExtensible(baz) && !baz.hasOwnProperty('__filemeta')) {
+if (typeof baz !== 'undefined' && baz && baz === Object(baz) && Object.isExtensible(baz) && !Object.prototype.hasOwnProperty.call(baz, '__filemeta')) {
   Object.defineProperty(baz, '__filemeta', {
     configurable: true,
     value: {
@@ -142,7 +142,7 @@ if (typeof baz !== 'undefined' && baz && baz === Object(baz) && Object.isExtensi
   });
 }
 
-if (typeof bar !== 'undefined' && bar && bar === Object(bar) && Object.isExtensible(bar) && !bar.hasOwnProperty('__filemeta')) {
+if (typeof bar !== 'undefined' && bar && bar === Object(bar) && Object.isExtensible(bar) && !Object.prototype.hasOwnProperty.call(bar, '__filemeta')) {
   Object.defineProperty(bar, '__filemeta', {
     configurable: true,
     value: {
@@ -152,7 +152,7 @@ if (typeof bar !== 'undefined' && bar && bar === Object(bar) && Object.isExtensi
   });
 }
 
-if (typeof foo !== 'undefined' && foo && foo === Object(foo) && Object.isExtensible(foo) && !foo.hasOwnProperty('__filemeta')) {
+if (typeof foo !== 'undefined' && foo && foo === Object(foo) && Object.isExtensible(foo) && !Object.prototype.hasOwnProperty.call(foo, '__filemeta')) {
   Object.defineProperty(foo, '__filemeta', {
     configurable: true,
     value: {
@@ -166,7 +166,7 @@ export let foo1 = 5,
     bar1 = () => {};
 /* ExportNamedDeclaration with Function and Class declarations */
 
-if (typeof bar1 !== 'undefined' && bar1 && bar1 === Object(bar1) && Object.isExtensible(bar1) && !bar1.hasOwnProperty('__filemeta')) {
+if (typeof bar1 !== 'undefined' && bar1 && bar1 === Object(bar1) && Object.isExtensible(bar1) && !Object.prototype.hasOwnProperty.call(bar1, '__filemeta')) {
   Object.defineProperty(bar1, '__filemeta', {
     configurable: true,
     value: {
@@ -176,7 +176,7 @@ if (typeof bar1 !== 'undefined' && bar1 && bar1 === Object(bar1) && Object.isExt
   });
 }
 
-if (typeof foo1 !== 'undefined' && foo1 && foo1 === Object(foo1) && Object.isExtensible(foo1) && !foo1.hasOwnProperty('__filemeta')) {
+if (typeof foo1 !== 'undefined' && foo1 && foo1 === Object(foo1) && Object.isExtensible(foo1) && !Object.prototype.hasOwnProperty.call(foo1, '__filemeta')) {
   Object.defineProperty(foo1, '__filemeta', {
     configurable: true,
     value: {
@@ -188,7 +188,7 @@ if (typeof foo1 !== 'undefined' && foo1 && foo1 === Object(foo1) && Object.isExt
 
 export function foo2() {}
 
-if (typeof foo2 !== 'undefined' && foo2 && foo2 === Object(foo2) && Object.isExtensible(foo2) && !foo2.hasOwnProperty('__filemeta')) {
+if (typeof foo2 !== 'undefined' && foo2 && foo2 === Object(foo2) && Object.isExtensible(foo2) && !Object.prototype.hasOwnProperty.call(foo2, '__filemeta')) {
   Object.defineProperty(foo2, '__filemeta', {
     configurable: true,
     value: {
@@ -200,7 +200,7 @@ if (typeof foo2 !== 'undefined' && foo2 && foo2 === Object(foo2) && Object.isExt
 
 export class Bar2 {}
 
-if (typeof Bar2 !== 'undefined' && Bar2 && Bar2 === Object(Bar2) && Object.isExtensible(Bar2) && !Bar2.hasOwnProperty('__filemeta')) {
+if (typeof Bar2 !== 'undefined' && Bar2 && Bar2 === Object(Bar2) && Object.isExtensible(Bar2) && !Object.prototype.hasOwnProperty.call(Bar2, '__filemeta')) {
   Object.defineProperty(Bar2, '__filemeta', {
     configurable: true,
     value: {
@@ -216,7 +216,7 @@ exports[`export-metadata re-export re export default 1`] = `
 import __DOCZ_DUMMY_EXPORT_DEFAULT from \\"../assets/a\\";
 export default __DOCZ_DUMMY_EXPORT_DEFAULT;
 
-if (typeof __DOCZ_DUMMY_EXPORT_DEFAULT !== 'undefined' && __DOCZ_DUMMY_EXPORT_DEFAULT && __DOCZ_DUMMY_EXPORT_DEFAULT === Object(__DOCZ_DUMMY_EXPORT_DEFAULT) && Object.isExtensible(__DOCZ_DUMMY_EXPORT_DEFAULT) && !__DOCZ_DUMMY_EXPORT_DEFAULT.hasOwnProperty('__filemeta')) {
+if (typeof __DOCZ_DUMMY_EXPORT_DEFAULT !== 'undefined' && __DOCZ_DUMMY_EXPORT_DEFAULT && __DOCZ_DUMMY_EXPORT_DEFAULT === Object(__DOCZ_DUMMY_EXPORT_DEFAULT) && Object.isExtensible(__DOCZ_DUMMY_EXPORT_DEFAULT) && !Object.prototype.hasOwnProperty.call(__DOCZ_DUMMY_EXPORT_DEFAULT, '__filemeta')) {
   Object.defineProperty(__DOCZ_DUMMY_EXPORT_DEFAULT, '__filemeta', {
     configurable: true,
     value: {
@@ -231,7 +231,7 @@ exports[`export-metadata re-export re export default to name 1`] = `
 "/* Re-export  */
 export { default as aDefault } from '../assets/a';
 
-if (typeof aDefault !== 'undefined' && aDefault && aDefault === Object(aDefault) && Object.isExtensible(aDefault) && !aDefault.hasOwnProperty('__filemeta')) {
+if (typeof aDefault !== 'undefined' && aDefault && aDefault === Object(aDefault) && Object.isExtensible(aDefault) && !Object.prototype.hasOwnProperty.call(aDefault, '__filemeta')) {
   Object.defineProperty(aDefault, '__filemeta', {
     configurable: true,
     value: {
@@ -246,7 +246,7 @@ exports[`export-metadata re-export re export name 1`] = `
 "/* Re-export  */
 export { a } from '../assets/a';
 
-if (typeof a !== 'undefined' && a && a === Object(a) && Object.isExtensible(a) && !a.hasOwnProperty('__filemeta')) {
+if (typeof a !== 'undefined' && a && a === Object(a) && Object.isExtensible(a) && !Object.prototype.hasOwnProperty.call(a, '__filemeta')) {
   Object.defineProperty(a, '__filemeta', {
     configurable: true,
     value: {
@@ -262,7 +262,7 @@ exports[`export-metadata re-export re export name to default 1`] = `
 import a from \\"../assets/a\\";
 export default a;
 
-if (typeof a !== 'undefined' && a && a === Object(a) && Object.isExtensible(a) && !a.hasOwnProperty('__filemeta')) {
+if (typeof a !== 'undefined' && a && a === Object(a) && Object.isExtensible(a) && !Object.prototype.hasOwnProperty.call(a, '__filemeta')) {
   Object.defineProperty(a, '__filemeta', {
     configurable: true,
     value: {
@@ -277,7 +277,7 @@ exports[`export-metadata re-export re export name to name 1`] = `
 "/* Re-export  */
 export { a as aa } from '../assets/a';
 
-if (typeof aa !== 'undefined' && aa && aa === Object(aa) && Object.isExtensible(aa) && !aa.hasOwnProperty('__filemeta')) {
+if (typeof aa !== 'undefined' && aa && aa === Object(aa) && Object.isExtensible(aa) && !Object.prototype.hasOwnProperty.call(aa, '__filemeta')) {
   Object.defineProperty(aa, '__filemeta', {
     configurable: true,
     value: {


### PR DESCRIPTION
Fixes #1287 (when using export * as).


Demo: 

```js
const obj = Object.create(null)
console.info([
  // true
  Object.isExtensible(obj),
  // false
  obj instanceof Object,
  // TypeError: obj.hasOwnProperty is not a function
  // obj.hasOwnProperty('key'),
  // false
  Object.prototype.hasOwnProperty.call(bar, 'key'),
])

Object.defineProperty(obj, 'key', {value: 1})
// true
console.info(Object.prototype.hasOwnProperty.call(obj, 'key'))
```