### PR TITLE
style: make sylus example alerts change with kind

### DIFF
--- a/examples/stylus/src/components/Alert.jsx
+++ b/examples/stylus/src/components/Alert.jsx
@@ -4,7 +4,8 @@ import t from 'prop-types'
 import './Alert.styl'
 
 export const Alert = ({ children, kind, ...rest }) => (
-  <div className="Alert" {...rest}>
+  // space used after alert in order to have kind remain as a separate name
+  <div className={'Alert ' + kind} {...rest}>
     {children}
   </div>
 )

--- a/examples/stylus/src/components/Alert.styl
+++ b/examples/stylus/src/components/Alert.styl
@@ -1,5 +1,19 @@
 .Alert {
-  padding: 1rem;
-  margin: 1rem;
-  border-radius: 0.25rem;
+  padding: .5rem
+  margin: 1rem
+  border-radius: 0.25rem
+  background-color: white
+  &.info {
+    color: white
+    background-color: #5352ED
+    }
+  &.positive {
+    background-color: #2ED573
+    }
+  &.negative {
+    background-color: #FF4757
+    }
+  &.warning {
+    background-color: #FFA502
+    }
 }


### PR DESCRIPTION
### Description

Added styling to stylus example, since `kind` from alert had no changes associated with it. 
In jsx added `kind` to the class, and in stylus added background colors based on other examples for each kind.

### Screenshots



| Before | After |
| ------ | ----- |
|<img width="1016" alt="Screen Shot 2021-02-21 at 10 02 40 PM" src="https://user-images.githubusercontent.com/30352852/108660676-a9558980-7490-11eb-903a-efd73713e96c.png"> |<img width="1020" alt="Screen Shot 2021-02-21 at 10 00 32 PM" src="https://user-images.githubusercontent.com/30352852/108660686-a9ee2000-7490-11eb-8e34-54825a76000c.png">  |