### PR TITLE
Update package.json to include the repository

### DIFF
--- a/core/docz-core/package.json
+++ b/core/docz-core/package.json
@@ -20,6 +20,11 @@
     "prepare": "yarn build",
     "test": "yarn jest"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/doczjs/docz.git",
+    "directory": "core/docz-core"
+  },
   "peerDependencies": {
     "typescript": "^3.5.0 || ^4.0.0"
   },

--- a/core/docz-rollup/package.json
+++ b/core/docz-rollup/package.json
@@ -15,6 +15,11 @@
   "peerDependencies": {
     "typescript": "^3.5.0 || ^4.0.0"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/doczjs/docz.git",
+    "directory": "core/docz-rollup"
+  },
   "dependencies": {
     "chalk": "^2.4.2",
     "figures": "3.0.0",

--- a/core/docz-utils/package.json
+++ b/core/docz-utils/package.json
@@ -18,6 +18,11 @@
     "lint": "eslint . --ext mdx,ts,tsx",
     "precommit": "lint-staged"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/doczjs/docz.git",
+    "directory": "core/docz-utils"
+  },
   "dependencies": {
     "@babel/generator": "^7.5.5",
     "@babel/parser": "^7.5.5",

--- a/core/docz/package.json
+++ b/core/docz/package.json
@@ -22,6 +22,11 @@
     "lint": "eslint . --ext mdx,ts,tsx",
     "precommit": "lint-staged"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/doczjs/docz.git",
+    "directory": "core/docz"
+  },
   "dependencies": {
     "@emotion/react": "^11.1.1",
     "@mdx-js/react": "^1.0.27",

--- a/core/gatsby-theme-docz/package.json
+++ b/core/gatsby-theme-docz/package.json
@@ -15,6 +15,11 @@
     "lint": "eslint . --ext .js",
     "precommit": "lint-staged"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/doczjs/docz.git",
+    "directory": "core/gatsby-theme-docz"
+  },
   "dependencies": {
     "@emotion/react": "^11.1.1",
     "@emotion/styled": "^11.0.0",

--- a/core/rehype-docz/package.json
+++ b/core/rehype-docz/package.json
@@ -19,6 +19,11 @@
     "precommit": "lint-staged",
     "test": "jest"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/doczjs/docz.git",
+    "directory": "core/rehype-docz"
+  },
   "dependencies": {
     "brace": "^0.11.1",
     "docz-utils": "2.3.3-alpha.0",

--- a/core/remark-docz/package.json
+++ b/core/remark-docz/package.json
@@ -19,6 +19,11 @@
     "precommit": "lint-staged",
     "test": "jest"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/doczjs/docz.git",
+    "directory": "core/remark-docz"
+  },
   "dependencies": {
     "@babel/generator": "^7.5.5",
     "@babel/types": "^7.5.5",


### PR DESCRIPTION
Hi there!
This change adds the repository property to your package.json file(s). Having this available provides a number of benefits to security tooling. For example, it allows for greater trust by checking for signed commits, contributors to a release and validating history with the project. It also allows for comparison between the source code and the published artifact in order to detect attacks on authors during the publication process.
We validate that we're making a PR against the correct repository by comparing the metadata for the published artifact on [npmjs.com](www.npmjs.com) against the metadata in the package.json file in the repository.
This change is provided by a team at Microsoft -- we're happy to answer any questions you may have. (Members of this team include [@s-tuli](https://github.com/s-tuli), [@iarna](https://github.com/iarna), [@v-rr](https://github.com/v-rr), [@v-jiepeng](https://github.com/v-jiepeng), [@v-zhzhou](https://github.com/v-zhzhou) and [@v-gjy](https://github.com/v-gjy)). If you would prefer that we not make these sorts of PRs to projects you maintain, please just say. If you'd like to learn more about what we're doing here, we've prepared a document talking about both this project and some of our other activities around supply chain security here: [microsoft/Secure-Supply-Chain](https://github.com/microsoft/Secure-Supply-Chain)
This PR provides repository metadata for the following packages:
* docz
* docz-core
* docz-rollup
* docz-utils
* gatsby-theme-docz
* rehype-docz
* remark-docz

