### PR TITLE
Update package.json to include the repository

### DIFF
--- a/core/docz-core/package.json
+++ b/core/docz-core/package.json
@@ -11,6 +11,11 @@
     "package.json",
     "README.md"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/doczjs/docz.git",
+    "directory": "core/docz-core"
+  },
   "scripts": {
     "build": "yarn cross-env NODE_ENV=production rollup -c",
     "dev": "yarn cross-env NODE_ENV=development yarn build -w",

--- a/core/docz-rollup/package.json
+++ b/core/docz-rollup/package.json
@@ -7,6 +7,11 @@
     "src/",
     "package.json"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/doczjs/docz.git",
+    "directory": "core/docz-rollup"
+  },
   "scripts": {
     "fix": "yarn lint --fix",
     "lint": "eslint . --ext .js",

--- a/core/docz-utils/package.json
+++ b/core/docz-utils/package.json
@@ -11,6 +11,11 @@
     "package.json",
     "README.md"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/doczjs/docz.git",
+    "directory": "core/docz-utils"
+  },
   "scripts": {
     "dev": "cross-env NODE_ENV=development yarn build -w",
     "build": "trash lib && cross-env NODE_ENV=production rollup -c",

--- a/core/docz/package.json
+++ b/core/docz/package.json
@@ -15,6 +15,11 @@
     "package.json",
     "README.md"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/doczjs/docz.git",
+    "directory": "core/docz"
+  },
   "scripts": {
     "dev": "cross-env NODE_ENV=development yarn build -w",
     "build": "cross-env NODE_ENV=production rollup -c",

--- a/core/gatsby-theme-docz/package.json
+++ b/core/gatsby-theme-docz/package.json
@@ -9,6 +9,11 @@
     "gatsby-theme",
     "docz"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/doczjs/docz.git",
+    "directory": "core/gatsby-theme-docz"
+  },
   "scripts": {
     "dev": "echo noop",
     "fix": "yarn lint --fix",

--- a/core/rehype-docz/package.json
+++ b/core/rehype-docz/package.json
@@ -11,6 +11,11 @@
     "package.json",
     "README.md"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/doczjs/docz.git",
+    "directory": "core/rehype-docz"
+  },
   "scripts": {
     "dev": "cross-env NODE_ENV=development yarn build -w",
     "build": "cross-env NODE_ENV=production rollup -c",

--- a/core/remark-docz/package.json
+++ b/core/remark-docz/package.json
@@ -11,6 +11,11 @@
     "package.json",
     "README.md"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/doczjs/docz.git",
+    "directory": "core/remark-docz"
+  },
   "scripts": {
     "dev": "cross-env NODE_ENV=development yarn build -w",
     "build": "cross-env NODE_ENV=production rollup -c",

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -2,6 +2,11 @@
   "name": "docz-example-basic",
   "version": "2.0.0",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/doczjs/docz.git",
+    "directory": "examples/basic"
+  },
   "scripts": {
     "dev": "docz dev",
     "build": "docz build",

--- a/other-packages/babel-plugin-export-metadata/package.json
+++ b/other-packages/babel-plugin-export-metadata/package.json
@@ -18,6 +18,11 @@
     "src/",
     "package.json"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/doczjs/docz.git",
+    "directory": "other-packages/babel-plugin-export-metadata"
+  },
   "scripts": {
     "fix": "yarn lint --fix",
     "lint": "eslint . --ext .js",

--- a/other-packages/eslint-config-docz-js/package.json
+++ b/other-packages/eslint-config-docz-js/package.json
@@ -12,6 +12,11 @@
     "index.js",
     "package.json"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/doczjs/docz.git",
+    "directory": "other-packages/eslint-config-docz-js"
+  },
   "scripts": {
     "fix": "run-s fix:*",
     "fix:prettier": "prettier \"**/*.js\" --write"

--- a/other-packages/eslint-config-docz-ts/package.json
+++ b/other-packages/eslint-config-docz-ts/package.json
@@ -12,6 +12,11 @@
     "index.js",
     "package.json"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/doczjs/docz.git",
+    "directory": "other-packages/eslint-config-docz-ts"
+  },
   "scripts": {
     "fix": "run-s fix:*",
     "fix:prettier": "prettier \"**/*.js\" --write"

--- a/other-packages/load-cfg/package.json
+++ b/other-packages/load-cfg/package.json
@@ -11,6 +11,11 @@
     "package.json",
     "README.md"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/doczjs/docz.git",
+    "directory": "other-packages/load-cfg"
+  },
   "scripts": {
     "dev": "cross-env NODE_ENV=development yarn build -w",
     "build": "cross-env NODE_ENV=production rollup -c",

--- a/other-packages/react-docgen-actual-name-handler/package.json
+++ b/other-packages/react-docgen-actual-name-handler/package.json
@@ -10,6 +10,11 @@
     "package.json",
     "README.md"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/doczjs/docz.git",
+    "directory": "other-packages/react-docgen-actual-name-handler"
+  },
   "scripts": {
     "dev": "cross-env NODE_ENV=development yarn build -w",
     "build": "cross-env NODE_ENV=production rollup -c",


### PR DESCRIPTION
Hi there!
This change adds the repository property to your package.json file(s). Having this available provides a number of benefits to security tooling. For example, it allows for greater trust by checking for signed commits, contributors to a release and validating history with the project. It also allows for comparison between the source code and the published artifact in order to detect attacks on authors during the publication process.
We validate that we're making a PR against the correct repository by comparing the metadata for the published artifact on [npmjs.com](www.npmjs.com) against the metadata in the package.json file in the repository.
This change is provided by a team at Microsoft -- we're happy to answer any questions you may have. (Members of this team include [@s-tuli](https://github.com/s-tuli), [@iarna](https://github.com/iarna), [@v-rr](https://github.com/v-rr), [@v-jiepeng](https://github.com/v-jiepeng), [@v-zhzhou](https://github.com/v-zhzhou) and [@v-gjy](https://github.com/v-gjy)). If you would prefer that we not make these sorts of PRs to projects you maintain, please just say. If you'd like to learn more about what we're doing here, we've prepared a document talking about both this project and some of our other activities around supply chain security here: [microsoft/Secure-Supply-Chain](https://github.com/microsoft/Secure-Supply-Chain)
This PR provides repository metadata for the following packages:
* docz
* docz-core
* docz-rollup
* docz-utils
* gatsby-theme-docz
* rehype-docz
* remark-docz
* docz-example-basic
* babel-plugin-export-metadata
* eslint-config-docz-js
* eslint-config-docz-ts
* load-cfg
* react-docgen-actual-name-handler