### PR TITLE
Style: Inherit border radius in live editor

### DIFF
--- a/core/gatsby-theme-docz/src/components/Playground/styles.js
+++ b/core/gatsby-theme-docz/src/components/Playground/styles.js
@@ -9,6 +9,7 @@ export const editor = theme => ({
   '* > textarea:focus': {
     outline: 'none',
   },
+  borderRadius: 'inherit',
 })
 
 export const error = {


### PR DESCRIPTION
### Description

The live editor has rounded edges, but the child `div` (which has a background) does not inherit the `border-radius`, leading to imperfect edges!

### Screenshots

Focus on the bottom left corner of each image!

| Before | After |
| ----- | ----- |
|  <img width="206" alt="Screenshot 2022-01-07 at 11 42 56" src="https://user-images.githubusercontent.com/44526664/148539949-1f984b15-6c16-4302-9d95-a5ee0938f79f.png"> | <img width="205" alt="Screenshot 2022-01-07 at 11 42 45" src="https://user-images.githubusercontent.com/44526664/148539983-cf038e3b-c87c-4fe9-a6eb-07abe2017953.png">  |