### PR TITLE
Fix: Support react 17 Issue #1662

### DIFF
--- a/core/docz/package.json
+++ b/core/docz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docz",
-  "version": "2.3.3-alpha.0",
+  "version": "2.3.3-alpha.1",
   "description": "It's has never been so easy to documents your things!",
   "license": "MIT",
   "main": "dist/index.js",
@@ -37,7 +37,7 @@
     "gatsby": "^2.13.27",
     "gatsby-plugin-eslint": "^2.0.5",
     "gatsby-plugin-typescript": "^2.1.6",
-    "gatsby-theme-docz": "2.3.3-alpha.0",
+    "gatsby-theme-docz": "2.3.3-alpha.1",
     "lodash": "^4.17.14",
     "marksy": "^8.0.0",
     "match-sorter": "^3.1.1",
@@ -48,7 +48,7 @@
     "yargs": "^13.3.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.2",
+    "react-dom": "^16.8.0 || ^17.0.2"
   }
 }

--- a/core/gatsby-theme-docz/package.json
+++ b/core/gatsby-theme-docz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-theme-docz",
-  "version": "2.3.3-alpha.0",
+  "version": "2.3.3-alpha.1",
   "description": "Gatsby theme created to use Docz",
   "license": "MIT",
   "author": "Pedro Nauck (pedronauck@gmail.com)",
@@ -60,8 +60,8 @@
   },
   "peerDependencies": {
     "docz": ">=2.0.0",
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.2",
+    "react-dom": "^16.8.0 || ^17.0.2"
   },
   "gitHead": "74932cd67112bacd1e29780a202d466acdd79535"
 }


### PR DESCRIPTION
### Description

Add React 17 to peer dependencies to not break when used within an updated project

### Review

- [X] Check the copy
- [X] Build package and install with yarn link

### Pre-merge checklist

- [X] Check for versions

### Screenshots

Not needed