### PR TITLE
chore(docs): Replace ref to master by ref to main

### DIFF
--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -11,7 +11,7 @@ yarn create docz-app docz-app-basic
 ## Download manually
 
 ```sh
-curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/basic
+curl https://codeload.github.com/doczjs/docz/tar.gz/main | tar -xz --strip=2 docz-main/examples/basic
 mv basic docz-basic-example
 cd docz-basic-example
 ```

--- a/examples/create-react-app-ts/README.md
+++ b/examples/create-react-app-ts/README.md
@@ -11,7 +11,7 @@ yarn create docz-app docz-app-cra --example create-react-app-ts
 ## Download manually
 
 ```sh
-curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/cra
+curl https://codeload.github.com/doczjs/docz/tar.gz/main | tar -xz --strip=2 docz-main/examples/cra
 mv cra docz-cra-example
 cd docz-cra-example
 ```

--- a/examples/create-react-app/README.md
+++ b/examples/create-react-app/README.md
@@ -11,7 +11,7 @@ yarn create docz-app docz-app-cra --example create-react-app
 ## Download manually
 
 ```sh
-curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/create-react-app
+curl https://codeload.github.com/doczjs/docz/tar.gz/main | tar -xz --strip=2 docz-main/examples/create-react-app
 mv create-react-app docz-cra-example
 cd docz-cra-example
 ```

--- a/examples/custom-base-path/README.md
+++ b/examples/custom-base-path/README.md
@@ -11,7 +11,7 @@ yarn create docz-app docz-app-custom-base-path -- example custom-base-path
 ## Download manually
 
 ```sh
-curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/custom-base-path
+curl https://codeload.github.com/doczjs/docz/tar.gz/main | tar -xz --strip=2 docz-main/examples/custom-base-path
 mv basic docz-custom-base-path-example
 cd docz-custom-base-path-example
 ```

--- a/examples/custom-config-location/README.md
+++ b/examples/custom-config-location/README.md
@@ -11,7 +11,7 @@ yarn create docz-app docz-app --example custom-config-location
 ## Download manually
 
 ```sh
-curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/custom-config-location
+curl https://codeload.github.com/doczjs/docz/tar.gz/main | tar -xz --strip=2 docz-main/examples/custom-config-location
 mv custom-config-location docz-custom-config-location-example
 cd docz-custom-config-location-example
 ```

--- a/examples/flow/README.md
+++ b/examples/flow/README.md
@@ -11,7 +11,7 @@ yarn create docz-app docz-app-flow --example flow
 ## Download manually
 
 ```sh
-curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/flow
+curl https://codeload.github.com/doczjs/docz/tar.gz/main | tar -xz --strip=2 docz-main/examples/flow
 mv flow docz-flow-example
 cd docz-flow-example
 ```

--- a/examples/gatsby/README.md
+++ b/examples/gatsby/README.md
@@ -14,7 +14,7 @@ yarn create docz-app docz-app-gatsby --example gatsby
 ## Download
 
 ```sh
-curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/gatsby
+curl https://codeload.github.com/doczjs/docz/tar.gz/main | tar -xz --strip=2 docz-main/examples/gatsby
 mv gatsby docz-gatsby-example
 cd docz-gatsby-example
 ```

--- a/examples/images/README.md
+++ b/examples/images/README.md
@@ -11,7 +11,7 @@ yarn create docz-app docz-app-images --example images
 ## Download manually
 
 ```sh
-curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/images
+curl https://codeload.github.com/doczjs/docz/tar.gz/main | tar -xz --strip=2 docz-main/examples/images
 mv images docz-images-example
 cd docz-images-example
 ```

--- a/examples/less/README.md
+++ b/examples/less/README.md
@@ -11,7 +11,7 @@ yarn create docz-app docz-app-less --example less
 ## Download manually
 
 ```sh
-curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/less
+curl https://codeload.github.com/doczjs/docz/tar.gz/main | tar -xz --strip=2 docz-main/examples/less
 mv less docz-less-example
 cd docz-less-example
 ```

--- a/examples/logo-in-sidebar/README.md
+++ b/examples/logo-in-sidebar/README.md
@@ -11,7 +11,7 @@ yarn create docz-app docz-app-logo-in-sidebar --example logo-in-sidebar
 ## Download manually
 
 ```sh
-curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/logo-in-sidebar
+curl https://codeload.github.com/doczjs/docz/tar.gz/main | tar -xz --strip=2 docz-main/examples/logo-in-sidebar
 mv logo-in-sidebar docz-logo-in-sidebar-example
 cd docz-logo-in-sidebar-example
 ```

--- a/examples/material-ui/README.md
+++ b/examples/material-ui/README.md
@@ -11,7 +11,7 @@ yarn create docz-app docz-app-basic --example material-ui
 ## Download manually
 
 ```sh
-curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/material-ui
+curl https://codeload.github.com/doczjs/docz/tar.gz/main | tar -xz --strip=2 docz-main/examples/material-ui
 mv material-ui docz-material-ui-example
 cd docz-material-ui-example
 ```

--- a/examples/monorepo-package/README.md
+++ b/examples/monorepo-package/README.md
@@ -14,7 +14,7 @@ yarn create docz-app docz-app-monorepo --example monorepo-package
 ## Download
 
 ```sh
-curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/monorepo-package
+curl https://codeload.github.com/doczjs/docz/tar.gz/main | tar -xz --strip=2 docz-main/examples/monorepo-package
 mv monorepo-package docz-monorepo-example
 cd docz-monorepo-example
 ```

--- a/examples/monorepo-package/packages/basic/README.md
+++ b/examples/monorepo-package/packages/basic/README.md
@@ -11,7 +11,7 @@ yarn create docz-app docz-app-basic
 ## Download manually
 
 ```sh
-curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/basic
+curl https://codeload.github.com/doczjs/docz/tar.gz/main | tar -xz --strip=2 docz-main/examples/basic
 mv basic docz-basic-example
 cd docz-basic-example
 ```

--- a/examples/monorepo-separate-docs/README.md
+++ b/examples/monorepo-separate-docs/README.md
@@ -16,7 +16,7 @@ yarn create docz-app docz-app-monorepo-separate-docs --example monorepo-separate
 ## Download
 
 ```sh
-curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/monorepo-separate-docs
+curl https://codeload.github.com/doczjs/docz/tar.gz/main | tar -xz --strip=2 docz-main/examples/monorepo-separate-docs
 mv monorepo-separate-docs docz-monorepo-separate-docs-example
 cd docz-monorepo-separate-docs-example
 ```

--- a/examples/monorepo/README.md
+++ b/examples/monorepo/README.md
@@ -14,7 +14,7 @@ yarn create docz-app docz-app-monorepo --example monorepo
 ## Download
 
 ```sh
-curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/monorepo
+curl https://codeload.github.com/doczjs/docz/tar.gz/main | tar -xz --strip=2 docz-main/examples/monorepo
 mv monorepo docz-monorepo-example
 cd docz-monorepo-example
 ```

--- a/examples/monorepo/packages/basic/README.md
+++ b/examples/monorepo/packages/basic/README.md
@@ -11,7 +11,7 @@ yarn create docz-app docz-app-basic
 ## Download manually
 
 ```sh
-curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/basic
+curl https://codeload.github.com/doczjs/docz/tar.gz/main | tar -xz --strip=2 docz-main/examples/basic
 mv basic docz-basic-example
 cd docz-basic-example
 ```

--- a/examples/now/README.md
+++ b/examples/now/README.md
@@ -11,7 +11,7 @@ yarn create docz-app docz-app-now --example now
 ## Download manually
 
 ```sh
-curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/now
+curl https://codeload.github.com/doczjs/docz/tar.gz/main | tar -xz --strip=2 docz-main/examples/now
 mv now docz-example-now
 docz-example-now
 ```

--- a/examples/react-router/README.md
+++ b/examples/react-router/README.md
@@ -11,7 +11,7 @@ yarn create docz-app docz-app-react-router --example react-router
 ## Download manually
 
 ```sh
-curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/react-router
+curl https://codeload.github.com/doczjs/docz/tar.gz/main | tar -xz --strip=2 docz-main/examples/react-router
 mv react-router docz-react-router-example
 cd docz-react-router-example
 ```

--- a/examples/sass/README.md
+++ b/examples/sass/README.md
@@ -11,7 +11,7 @@ yarn create docz-app docz-app-sass --example sass
 ## Download manually
 
 ```sh
-curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/sass
+curl https://codeload.github.com/doczjs/docz/tar.gz/main | tar -xz --strip=2 docz-main/examples/sass
 mv sass docz-sass-example
 cd docz-sass-example
 ```

--- a/examples/shadowed-playground/README.md
+++ b/examples/shadowed-playground/README.md
@@ -11,7 +11,7 @@ yarn create docz-app docz-app-shadowed-playground
 ## Download manually
 
 ```sh
-curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/shadowed-playground
+curl https://codeload.github.com/doczjs/docz/tar.gz/main | tar -xz --strip=2 docz-main/examples/shadowed-playground
 mv shadowed-playground docz-shadowed-playground-example
 cd docz-shadowed-playground-example
 ```

--- a/examples/styled-components/README.md
+++ b/examples/styled-components/README.md
@@ -11,7 +11,7 @@ yarn create docz-app docz-app-styled-docz --example styled-components
 ## Download manually
 
 ```sh
-curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/styled-components
+curl https://codeload.github.com/doczjs/docz/tar.gz/main | tar -xz --strip=2 docz-main/examples/styled-components
 mv styled-components docz-example-styled-docz
 ```
 

--- a/examples/stylus/README.md
+++ b/examples/stylus/README.md
@@ -11,7 +11,7 @@ yarn create docz-app docz-app-stylus --example stylus
 ## Download manually
 
 ```sh
-curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/stylus
+curl https://codeload.github.com/doczjs/docz/tar.gz/main | tar -xz --strip=2 docz-main/examples/stylus
 mv stylus docz-stylus-example
 cd docz-stylus-example
 ```

--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -11,7 +11,7 @@ yarn create docz-app docz-app-typescript --example typescript
 ## Download manually
 
 ```sh
-curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/typescript
+curl https://codeload.github.com/doczjs/docz/tar.gz/main | tar -xz --strip=2 docz-main/examples/typescript
 mv typescript docz-typescript-example
 cd docz-typescript-example
 ```

--- a/examples/webpack-alias/README.md
+++ b/examples/webpack-alias/README.md
@@ -11,7 +11,7 @@ yarn create docz-app docz-app-webpack-alias --example webpack-alias
 ## Download manually
 
 ```sh
-curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/webpack-alias
+curl https://codeload.github.com/doczjs/docz/tar.gz/main | tar -xz --strip=2 docz-main/examples/webpack-alias
 mv webpack-alias docz-webpack-alias-example
 cd docz-webpack-alias-example
 ```

--- a/examples/with-algolia-search/README.md
+++ b/examples/with-algolia-search/README.md
@@ -21,7 +21,7 @@ yarn create docz-app docz-app-with-algolia-search --example with-algolia-search
 ## Download manually
 
 ```sh
-curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/with-algolia-search
+curl https://codeload.github.com/doczjs/docz/tar.gz/main | tar -xz --strip=2 docz-main/examples/with-algolia-search
 mv with-algolia-search docz-with-algolia-search-example
 cd docz-with-algolia-search-example
 ```

--- a/examples/with-custom-404-page/README.md
+++ b/examples/with-custom-404-page/README.md
@@ -22,7 +22,7 @@ yarn create docz-app docz-app-basic --example with-custom-404-page
 ## Download manually
 
 ```sh
-curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/with-custom-404-page
+curl https://codeload.github.com/doczjs/docz/tar.gz/main | tar -xz --strip=2 docz-main/examples/with-custom-404-page
 mv with-custom-404-page docz-with-custom-404-page-example
 cd docz-with-custom-404-page-example
 ```

--- a/examples/with-custom-docz-theme/README.md
+++ b/examples/with-custom-docz-theme/README.md
@@ -87,7 +87,7 @@ yarn create docz-app docz-app-with-custom-docz-theme
 ## Download manually
 
 ```sh
-curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/with-custom-docz-theme
+curl https://codeload.github.com/doczjs/docz/tar.gz/main | tar -xz --strip=2 docz-main/examples/with-custom-docz-theme
 mv with-custom-docz-theme docz-with-custom-docz-theme-example
 cd docz-with-custom-docz-theme-example
 ```

--- a/examples/with-custom-links/README.md
+++ b/examples/with-custom-links/README.md
@@ -11,7 +11,7 @@ yarn create docz-app docz-app-with-custom-links --example with-custom-links
 ## Download manually
 
 ```sh
-curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/with-custom-links
+curl https://codeload.github.com/doczjs/docz/tar.gz/main | tar -xz --strip=2 docz-main/examples/with-custom-links
 mv with-custom-links docz-with-custom-links-example
 cd docz-with-custom-links-example
 ```

--- a/examples/with-decorators/README.md
+++ b/examples/with-decorators/README.md
@@ -11,7 +11,7 @@ yarn create docz-app docz-app-with-decorators --example with-decorators
 ## Download manually
 
 ```sh
-curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/with-decorators
+curl https://codeload.github.com/doczjs/docz/tar.gz/main | tar -xz --strip=2 docz-main/examples/with-decorators
 mv with-decorators docz-with-decorators-example
 cd docz-with-decorators-example
 ```

--- a/examples/with-env-variables/README.md
+++ b/examples/with-env-variables/README.md
@@ -11,14 +11,14 @@ yarn create docz-app docz-app-with-env-variables
 ## Download manually
 
 ```sh
-curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/with-env-variables
+curl https://codeload.github.com/doczjs/docz/tar.gz/main | tar -xz --strip=2 docz-main/examples/with-env-variables
 mv with-env-variables docz-with-env-variables-example
 cd docz-with-env-variables-example
 ```
 
 ## Notes
 
-Environment variables are defined in `gatsby-node.js` by changing the webpack config (process.env.FOO, process.env.PROD) or in .env.* and then imported using `dotenv` in `gatsby-config.js` (process.env.GATSBY_API_URL). 
+Environment variables are defined in `gatsby-node.js` by changing the webpack config (process.env.FOO, process.env.PROD) or in .env.* and then imported using `dotenv` in `gatsby-config.js` (process.env.GATSBY_API_URL).
 
 ## Setup
 

--- a/examples/with-favicon-and-metadata/README.md
+++ b/examples/with-favicon-and-metadata/README.md
@@ -11,7 +11,7 @@ yarn create docz-app docz-app-with-favicon-and-metadata --example with-favicon-a
 ## Download manually
 
 ```sh
-curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/with-favicon-and-metadata
+curl https://codeload.github.com/doczjs/docz/tar.gz/main | tar -xz --strip=2 docz-main/examples/with-favicon-and-metadata
 mv with-favicon-and-metadata docz-with-favicon-and-metadata-example
 cd docz-with-favicon-and-metadata-example
 ```

--- a/examples/with-gatsby-remark-vscode/README.md
+++ b/examples/with-gatsby-remark-vscode/README.md
@@ -13,7 +13,7 @@ yarn create docz-app docz-app-with-gatsby-remark-vscode
 ## Download manually
 
 ```sh
-curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/with-gatsby-remark-vscode
+curl https://codeload.github.com/doczjs/docz/tar.gz/main | tar -xz --strip=2 docz-main/examples/with-gatsby-remark-vscode
 mv with-gatsby-remark-vscode docz-with-gatsby-remark-vscode-example
 cd docz-with-gatsby-remark-vscode-example
 ```

--- a/examples/with-styled-components-and-scoping/README.md
+++ b/examples/with-styled-components-and-scoping/README.md
@@ -11,7 +11,7 @@ yarn create docz-app docz-app-styled-docz --example with-styled-components-and-s
 ## Download manually
 
 ```sh
-curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/with-styled-components-and-scoping
+curl https://codeload.github.com/doczjs/docz/tar.gz/main | tar -xz --strip=2 docz-main/examples/with-styled-components-and-scoping
 mv with-styled-components-and-scoping docz-example-styled-docz
 ```
 

--- a/examples/with-themes-dir/README.md
+++ b/examples/with-themes-dir/README.md
@@ -11,7 +11,7 @@ yarn create docz-app docz-app-with-themes-dir
 ## Download manually
 
 ```sh
-curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/with-themes-dir
+curl https://codeload.github.com/doczjs/docz/tar.gz/main | tar -xz --strip=2 docz-main/examples/with-themes-dir
 mv with-themes-dir docz-with-themes-dir-example
 cd docz-with-themes-dir-example
 ```

--- a/examples/with-typescript-decorators/README.md
+++ b/examples/with-typescript-decorators/README.md
@@ -11,7 +11,7 @@ yarn create docz-app docz-app-with-typescript-decorators --example with-typescri
 ## Download manually
 
 ```sh
-curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/with-typescript-decorators
+curl https://codeload.github.com/doczjs/docz/tar.gz/main | tar -xz --strip=2 docz-main/examples/with-typescript-decorators
 mv with-typescript-decorators docz-with-typescript-decorators-example
 cd docz-with-typescript-decorators-example
 ```

--- a/examples/wrapped-playground/README.md
+++ b/examples/wrapped-playground/README.md
@@ -11,7 +11,7 @@ yarn create docz-app docz-app-wrapped-playground
 ## Download manually
 
 ```sh
-curl https://codeload.github.com/doczjs/docz/tar.gz/master | tar -xz --strip=2 docz-master/examples/wrapped-playground
+curl https://codeload.github.com/doczjs/docz/tar.gz/main | tar -xz --strip=2 docz-main/examples/wrapped-playground
 mv wrapped-playground docz-wrapped-playground-example
 cd docz-wrapped-playground-example
 ```


### PR DESCRIPTION
### Description

Examples with the curl download are refering to master instead of main.

### Review

- [ ] Check the copy
- [ ] ...
- [ ] ...

### Pre-merge checklist

- [ ] ...
- [ ] ...

### Screenshots

| Before | After |
| ------ | ----- |
| Image  | Image |