### PR TITLE
docs: Ref to master in Readme changed to ref to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,22 +118,22 @@ Start by building your site with `yarn docz build`, if you haven't provided a `d
 
 ## Examples
 
-- **[with basic](https://github.com/doczjs/docz/tree/master/examples/basic)**
-- **[with a gatsby site](https://github.com/doczjs/docz/tree/master/examples/gatsby)**
-- **[with react native](https://github.com/doczjs/docz/tree/master/examples/react-native)**
-- **[with styled-components](https://github.com/doczjs/docz/tree/master/examples/styled-components)**
-- **[with typescript](https://github.com/doczjs/docz/tree/master/examples/typescript)**
-- **[with algolia search](https://github.com/doczjs/docz/tree/master/examples/with-algolia-search)**
-- **[with gatsby-remark-vscode](https://github.com/doczjs/docz/tree/master/examples/with-gatsby-remark-vscode)**
-- **[with react-router](https://github.com/doczjs/docz/tree/master/examples/react-router)**
-- **[with flow](https://github.com/doczjs/docz/tree/master/examples/flow)**
-- **[with images](https://github.com/doczjs/docz/tree/master/examples/images)**
-- **[with sass](https://github.com/doczjs/docz/tree/master/examples/sass)**
-- **[with less](https://github.com/doczjs/docz/tree/master/examples/less)**
-- **[with stylus](https://github.com/doczjs/docz/tree/master/examples/css-stylus)**
+- **[with basic](https://github.com/doczjs/docz/tree/main/examples/basic)**
+- **[with a gatsby site](https://github.com/doczjs/docz/tree/main/examples/gatsby)**
+- **[with react native](https://github.com/doczjs/docz/tree/main/examples/react-native)**
+- **[with styled-components](https://github.com/doczjs/docz/tree/main/examples/styled-components)**
+- **[with typescript](https://github.com/doczjs/docz/tree/main/examples/typescript)**
+- **[with algolia search](https://github.com/doczjs/docz/tree/main/examples/with-algolia-search)**
+- **[with gatsby-remark-vscode](https://github.com/doczjs/docz/tree/main/examples/with-gatsby-remark-vscode)**
+- **[with react-router](https://github.com/doczjs/docz/tree/main/examples/react-router)**
+- **[with flow](https://github.com/doczjs/docz/tree/main/examples/flow)**
+- **[with images](https://github.com/doczjs/docz/tree/main/examples/images)**
+- **[with sass](https://github.com/doczjs/docz/tree/main/examples/sass)**
+- **[with less](https://github.com/doczjs/docz/tree/main/examples/less)**
+- **[with stylus](https://github.com/doczjs/docz/tree/main/examples/css-stylus)**
 - **with css modules**: works out of the box.
 
-### You can check the complete list of docz examples [here](https://github.com/doczjs/docz/tree/master/examples).
+### You can check the complete list of docz examples [here](https://github.com/doczjs/docz/tree/main/examples).
 
 ## More info on [docz.site](https://docz.site)
 
@@ -148,7 +148,7 @@ Start by building your site with `yarn docz build`, if you haven't provided a `d
 - **[@umijs/hooks](https://hooks.umijs.org/)**: React Hooks Library.
 - **[React Yandex Maps](https://react-yandex-maps.now.sh/)**: Yandex Maps API bindings for React.
 - **[Components-extra](https://components-extra.netlify.com)**: Customizable react component blocks built with material-ui and styled-components.
-- **[Add your site](https://github.com/doczjs/docz/edit/master/README.md)**
+- **[Add your site](https://github.com/doczjs/docz/edit/main/README.md)**
 
 ## Contributors
 


### PR DESCRIPTION
### Description

Examples and Add your site section mentioned in Readme.md are referring to master instead of main.