### PR TITLE
fix(docz): fullpath and repoEditUrl should not add to config.src

### DIFF
--- a/core/docz-core/src/lib/Entry.ts
+++ b/core/docz-core/src/lib/Entry.ts
@@ -73,7 +73,7 @@ export class Entry {
 
   private getFilepath(config: Config, file: string): string {
     const root = paths.getRootDir(config)
-    const fullpath = path.resolve(root, config.src, file)
+    const fullpath = path.resolve(root, file)
     const filepath = path.relative(root, fullpath)
 
     if (process.platform === 'win32') {

--- a/core/docz-core/src/utils/repo-info.ts
+++ b/core/docz-core/src/utils/repo-info.ts
@@ -52,7 +52,7 @@ export const getRepoEditUrl = (config: Config): string | null => {
     if (!gitDir) return null
 
     const project = path.parse(gitDir).dir
-    const root = path.join(paths.getRootDir(config), config.src)
+    const root = paths.getRootDir(config)
     const relative = path.relative(project, root)
     const tree = getTree(repo, config.editBranch, relative)
 


### PR DESCRIPTION
### Description

The `src` options setting to `doczrc.js` cause `doc.fullpath` and `doc.repoEditUrl` error.

The `config.src` part set to `fullpath` and `repoEditUrl` is redundant.